### PR TITLE
feat : 부모자식 트랜스폼 계산 수정, 기즈모핸들 거리에 비례하여 사이즈 조절

### DIFF
--- a/Engine/Source/CoreUObject/Components/SceneComponent.cpp
+++ b/Engine/Source/CoreUObject/Components/SceneComponent.cpp
@@ -24,12 +24,12 @@ const FTransform USceneComponent::GetWorldTransform()
     if (Parent)
     {
         // 부모 월드 * 내 로컬
-        FMatrix ParentWorld = Parent->GetWorldTransform().GetMatrix();
+        //FMatrix ParentWorld = Parent->GetWorldTransform().GetMatrix();
 
-        FMatrix MyLocal = RelativeTransform.GetMatrix();
+        //FMatrix MyLocal = RelativeTransform.GetMatrix();
 
-        FMatrix NewMatrix = MyLocal * ParentWorld;
-        return NewMatrix.GetTransform();
+        //FMatrix NewMatrix = MyLocal * ParentWorld;
+        return Parent->GetWorldTransform() * RelativeTransform;
     }
 
     return RelativeTransform;
@@ -39,7 +39,6 @@ void USceneComponent::SetRelativeTransform(const FTransform& InTransform)
 {
     // 로컬 트랜스폼 갱신
     RelativeTransform = InTransform;
-    FVector Rot = RelativeTransform.GetRotation().GetEuler();
     UpdateBoundingBox();
 }
 
@@ -68,13 +67,13 @@ void USceneComponent::SetupAttachment(USceneComponent* InParent, bool bUpdateChi
 
 void USceneComponent::ApplyParentWorldTransform(const FTransform& ParentWorldTransform)
 {
-    FMatrix ParentWorld = ParentWorldTransform.GetMatrix();
-    FMatrix MyLocal = RelativeTransform.GetMatrix();
+    //FMatrix ParentWorld = ParentWorldTransform.GetMatrix();
+    //FMatrix MyLocal = RelativeTransform.GetMatrix();
 
-    FMatrix NewMatrix = MyLocal * ParentWorld.Inverse();
+    //FMatrix NewMatrix = MyLocal * ParentWorld.Inverse();
 
     // 로컬 트랜스폼 갱신
-    SetRelativeTransform(NewMatrix.GetTransform());
+    SetRelativeTransform(ParentWorldTransform * RelativeTransform);
     UpdateBoundingBox();
 
 }

--- a/Engine/Source/Gizmo/GizmoHandle.cpp
+++ b/Engine/Source/Gizmo/GizmoHandle.cpp
@@ -125,14 +125,15 @@ void AGizmoHandle::SetScaleByDistance()
     // 거리 계산
     float distance = (actorWorldPos - cameraWorldPos).Length();
 
-    float baseScale = 1.0f;    // 기본 스케일
-    float scaleFactor = distance * 0.1f; // 거리에 비례하여 스케일 증가
+    float baseScale = 3.0f;    // 기본 스케일
+    float scaleFactor = distance * (1.f/baseScale); // 거리에 비례하여 스케일 증d가
 
     // float minScale = 1.0f;     // 최소 스케일
     // float maxScale = 1.0f;     // 최대 스케일
     // float scaleFactor = clamp(1.0f / distance, minScale, maxScale);
 
     MyTransform.SetScale(scaleFactor, scaleFactor, scaleFactor);
+    SetActorTransform(MyTransform);
 }
 
 void AGizmoHandle::SetActive(bool bActive)


### PR DESCRIPTION
- 계층구조에서의 월드트랜스폼 반환로직 수정
- GizmoHandle의 사이즈가 카메라로부터의 거리에 비례하도록 수정