### PR TITLE
feat: FName System

### DIFF
--- a/Engine/Engine.vcxproj
+++ b/Engine/Engine.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -153,6 +153,8 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="Source\CoreUObject\NameTypes.h" />
+    <ClInclude Include="Source\CoreUObject\Name.h" />
     <ClInclude Include="Source\ThirdParty\IniParser\iniparser.hpp" />
     <ClInclude Include="Source\Core\AbstractClass\UClass.h" />
     <ClInclude Include="Source\Core\Rendering\RendererDefine.h" />
@@ -230,6 +232,7 @@
     <ClCompile Include="Source\CoreUObject\Components\SceneComponent.cpp" />
     <ClCompile Include="Source\CoreUObject\Object.cpp" />
     <ClCompile Include="Source\CoreUObject\ObjectFactory.cpp" />
+    <ClCompile Include="Source\CoreUObject\Name.cpp" />
     <ClCompile Include="Source\CoreUObject\World.cpp" />
     <ClCompile Include="Source\Core\AbstractClass\UClass.cpp" />
     <ClCompile Include="Source\Core\Container\String.cpp" />

--- a/Engine/Engine.vcxproj.filters
+++ b/Engine/Engine.vcxproj.filters
@@ -142,6 +142,9 @@
     <ClCompile Include="Source\Core\AbstractClass\UClass.cpp">
       <Filter>Source Files\Core\AbstractClass</Filter>
     </ClCompile>
+    <ClCompile Include="Source\CoreUObject\Name.cpp">
+      <Filter>Source Files\CoreUObject</Filter>
+    </ClCompile>
     <ClCompile Include="Source\Engine\EngineConfig.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -348,6 +351,12 @@
     </ClInclude>
     <ClInclude Include="Source\Core\AbstractClass\UClass.h">
       <Filter>Header Files\Core\AbstractClass</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\CoreUObject\NameTypes.h">
+      <Filter>Header Files\CoreUObject</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\CoreUObject\Name.h">
+      <Filter>Header Files\CoreUObject</Filter>
     </ClInclude>
     <ClInclude Include="Source\Engine\EngineConfig.h">
       <Filter>Header Files\Engine</Filter>

--- a/Engine/Source/Core/HAL/PlatformMemory.h
+++ b/Engine/Source/Core/HAL/PlatformMemory.h
@@ -61,6 +61,36 @@ public:
 
 	template <EAllocationType AllocType>
 	static uint64 GetAllocationCount();
+
+	/** Copies count bytes of characters from Src to Dest. If some regions of the source
+	 * area and the destination overlap, memmove ensures that the original source bytes
+	 * in the overlapping region are copied before being overwritten.  NOTE: make sure
+	 * that the destination buffer is the same size or larger than the source buffer!
+	 */
+	static FORCEINLINE void* Memmove(void* Dest, const void* Src, SIZE_T Count)
+	{
+		return memmove(Dest, Src, Count);
+	}
+
+	static FORCEINLINE int32 Memcmp(const void* Buf1, const void* Buf2, SIZE_T Count)
+	{
+		return memcmp(Buf1, Buf2, Count);
+	}
+
+	static FORCEINLINE void* Memset(void* Dest, uint8 Char, SIZE_T Count)
+	{
+		return memset(Dest, Char, Count);
+	}
+
+	static FORCEINLINE void* Memzero(void* Dest, SIZE_T Count)
+	{
+		return memset(Dest, 0, Count);
+	}
+
+	static FORCEINLINE void* Memcpy(void* Dest, const void* Src, SIZE_T Count)
+	{
+		return memcpy(Dest, Src, Count);
+	}
 };
 
 

--- a/Engine/Source/Core/Rendering/UI.cpp
+++ b/Engine/Source/Core/Rendering/UI.cpp
@@ -494,7 +494,7 @@ void UI::RenderSceneManager()
             
             if (bHasPrimitive)
             {
-                ImGui::Text(*Actor->GetName());
+                ImGui::Text(*Actor->GetName().ToString());
             }
         }
         

--- a/Engine/Source/Core/Template/Template.h
+++ b/Engine/Source/Core/Template/Template.h
@@ -1,4 +1,4 @@
-#include "HAL/PlatformMemory.h"
+﻿#include "HAL/PlatformMemory.h"
 #include "RemoveReference.h"
 
 /**
@@ -6,6 +6,24 @@
  */
 template<typename T> struct TIsLValueReferenceType { enum { Value = false }; };
 template<typename T> struct TIsLValueReferenceType<T&> { enum { Value = true }; };
+
+/**
+ * utility template for a class that should not be copyable.
+ * Derive from this class to make your class non-copyable
+ * 생성자와 소멸자를 protected로 선언하여 객체 생성을 막는다.
+ * 복사 생성자와 대입 연산자를 private로 선언하여 복사를 막는다.
+ */
+class FNoncopyable
+{
+protected:
+	// ensure the class cannot be constructed directly
+	FNoncopyable() {}
+	// the class should not be used polymorphically
+	~FNoncopyable() {}
+private:
+	FNoncopyable(const FNoncopyable&);
+	FNoncopyable& operator=(const FNoncopyable&);
+};
 
 /**
  * MoveTemp will cast a reference to an rvalue reference.

--- a/Engine/Source/CoreUObject/Name.cpp
+++ b/Engine/Source/CoreUObject/Name.cpp
@@ -1,0 +1,386 @@
+﻿#include "pch.h"
+#include "Name.h"
+#include "NameTypes.h"
+#include "HAL/PlatformType.h"
+#include "Container/Map.h"
+#include "AbstractClass/Singleton.h"
+
+struct FNameEntryIds
+{
+	FNameEntryId ComparisonId, DisplayId;
+};
+
+/*-----------------------------------------------------------------------------
+    FName helpers.
+-----------------------------------------------------------------------------*/
+
+/**
+ * ANSICAHR나 WIDECHAR를 담는 인터페이스
+ */
+struct FNameStringView
+{
+    FNameStringView() : Data(nullptr), Len(0), bIsWide(false) {}
+    FNameStringView(const ANSICHAR* Str, uint32 InLen) : Ansi(Str), Len(InLen), bIsWide(false) {}
+    FNameStringView(const WIDECHAR* Str, uint32 InLen) : Wide(Str), Len(InLen), bIsWide(true) {}
+    FNameStringView(const void* InData, uint32 InLen, bool bInIsWide) : Data(InData), Len(InLen), bIsWide(bInIsWide) {}
+
+    union
+    {
+        const void* Data;
+        const ANSICHAR* Ansi;
+        const WIDECHAR* Wide;
+    };
+
+    uint32 Len;
+    bool bIsWide;
+
+    bool IsAnsi() const { return !bIsWide; }
+};
+
+/*
+struct FNameHash
+{
+	uint32 Index;
+	FNameEntryHeader EntryProbeHeader; // 엔트리들을 조사할 때 동일성 확인에 도움을 줌
+
+#pragma region Hash - djb2
+	//TODO: int32 Len 파라미터 추가
+	template <typename CharType>
+	static uint32 GenerateHash(const CharType* Str)
+	{
+		// djb2 문자열 해싱 알고리즘
+		uint32 Hash = 5381;
+		while (*Str)
+		{
+			Hash = ((Hash << 5) + Hash) + *Str;
+			++Str;
+		}
+		return Hash;
+	}
+#pragma endregion
+
+	template<class CharType>
+	FNameHash(const CharType* Str, int32 Len)
+		: FNameHash(GenerateHash(Str), Len, sizeof(CharType) == sizeof(WIDECHAR))	//TODO: GenerateHash 함수에 Len 파라미터 추가
+	{}
+
+	FNameHash(uint64 Hash, int32 Len, bool bIsWide)
+	{
+		Index = Hash;
+		EntryProbeHeader.Len = Len;
+		EntryProbeHeader.bIsWide = bIsWide;
+	}
+
+};
+*/
+
+namespace // TODO: Use FNameHash, not uint32
+{
+	template <typename CharType>
+	uint32 HashString(const CharType* Str)
+	{
+		// djb2 문자열 해싱 알고리즘
+		uint32 Hash = 5381;
+		while (*Str)
+		{
+			Hash = ((Hash << 5) + Hash) + *Str;
+			++Str;
+		}
+		return Hash;
+	}
+
+	template <typename CharType>
+	FORCENOINLINE uint32 HashStringLower(const CharType* Str, uint32 InLen)
+	{
+		CharType LowerStr[NAME_SIZE];
+		if constexpr (std::is_same_v<CharType, wchar_t>)
+		{
+			for (uint32 i = 0; i < InLen; i++)
+			{
+				LowerStr[i] = towlower(Str[i]);
+			}
+			LowerStr[InLen] = '\0';
+		}
+		else
+		{
+			for (uint32 i = 0; i < InLen; ++i)
+			{
+				LowerStr[i] = static_cast<CharType>(tolower(Str[i]));
+			}
+			LowerStr[InLen] = '\0';
+		}
+		return HashString(LowerStr);
+	}
+
+	template <ENameCase Sensitivity>
+	uint32 HashName(FNameStringView InName);
+
+	template <>
+	uint32 HashName<ENameCase::IgnoreCase>(FNameStringView InName)
+	{
+		return InName.IsAnsi() ? HashStringLower(InName.Ansi, InName.Len) : HashStringLower(InName.Wide, InName.Len);
+	}
+
+	template <>
+	uint32 HashName<ENameCase::CaseSensitive>(FNameStringView InName)
+	{
+		return InName.IsAnsi() ? HashString(InName.Ansi) : HashString(InName.Wide);
+	}
+}
+
+template <ENameCase Sensitivity>
+struct FNameValue
+{
+	explicit FNameValue(FNameStringView InName)
+		: Name(InName)
+		, Hash(HashName<Sensitivity>(InName))
+	{}
+
+	FNameStringView Name;
+	uint32 Hash;	// TODO: Use FNameHash, not uint32
+#if WITH_CASE_PRESERVING_NAME
+	FNameEntryId ComparisonId;
+#endif
+};
+
+using FNameComparisonValue = FNameValue<ENameCase::IgnoreCase>;
+#if WITH_CASE_PRESERVING_NAME
+using FNameDisplayValue = FNameValue<ENameCase::CaseSensitive>;
+#endif
+
+/**
+ * FNameEntry를 관리하는 Pool 클래스
+ * @TODO: Shard 미구현!
+ */
+struct FNamePool : public TSingleton<FNamePool>
+{
+private:
+#if WITH_CASE_PRESERVING_NAME
+	TMap<uint32, FNameEntry> DisplayPool;	//TODO: uint32를 FNameEntryId로 변경
+#endif
+    TMap<uint32, FNameEntry> ComparisonPool;
+
+public:
+	//FNamePool();
+
+	FNameEntryId	Store(FNameStringView& View);
+	FNameEntryId	Find(FNameStringView View) const;
+
+	/** Hash로 원본 문자열을 가져옵니다. */
+	FNameEntry		Resolve(uint32 Hash) const { return *DisplayPool.Find(Hash); }	//TODO: FNameEntry&를 반환하는 FNameEntryId를 인자로 하도록 변경
+
+	//bool			IsValid(FNameEntryHandle Handle) const;
+
+	//FDisplayNameEntryId	StoreValue(const FNameComparisonValue& Value);
+
+	uint32			NumEntries() const { return DisplayPool.Num() + ComparisonPool.Num(); };
+private:
+	template <ENameCase Sensitivity>
+	FNameEntry MakeEntry(const FNameValue<Sensitivity>& Value) const
+	{
+		FNameEntry Result;
+		Result.ComparisonId = Value.ComparisonId;
+		Result.Header = {
+			.bIsWide = Value.Name.bIsWide,
+			.Len = static_cast<uint16>(Value.Name.Len)
+		};
+		if (Value.Name.bIsWide)
+		{
+			Result.StoreName(Value.Name.Wide, Value.Name.Len);
+		}
+		else
+		{
+			Result.StoreName(Value.Name.Ansi, Value.Name.Len);
+		}
+		return Result;
+	}
+
+public:
+	/**
+	 * 문자열을 찾거나, 없으면 Hash화 해서 저장합니다.
+	 *
+	 * @return DisplayName의 Hash
+	 */
+	FNameEntryId Store(const FNameStringView& Name)
+	{
+#if WITH_CASE_PRESERVING_NAME
+		// DisplayPool에 같은 문자열이 있다면, 문자열의 Hash 반환
+		FNameDisplayValue DisplayValue{ Name };
+		if (DisplayPool.Find(DisplayValue.Hash))
+		{
+			return { DisplayValue.Hash };
+		}
+#endif
+
+		const FNameComparisonValue ComparisonValue{ Name };
+		if (!ComparisonPool.Find(ComparisonValue.Hash))
+		{
+			const FNameEntry Entry = MakeEntry(ComparisonValue);
+			ComparisonPool.Add(ComparisonValue.Hash, Entry);
+		}
+
+		DisplayValue.ComparisonId = { ComparisonValue.Hash };
+		DisplayPool.Add(DisplayValue.Hash, MakeEntry(DisplayValue));
+		return { DisplayValue.Hash };
+	}
+};
+
+/*-----------------------------------------------------------------------------
+    FNameEntry
+-----------------------------------------------------------------------------*/
+
+void FNameEntry::StoreName(const ANSICHAR* InName, uint32 Len)
+{
+    FPlatformMemory::Memcpy(AnsiName, InName, sizeof(ANSICHAR) * Len);
+    AnsiName[Len] = '\0';
+}
+
+void FNameEntry::StoreName(const WIDECHAR* InName, uint32 Len)
+{
+    FPlatformMemory::Memcpy(WideName, InName, sizeof(WIDECHAR) * Len);
+    WideName[Len] = '\0';
+}
+
+/*
+void FNameEntry::CopyUnterminatedName(ANSICHAR* Out) const
+{
+    FPlatformMemory::Memcpy(Out, AnsiName, sizeof(ANSICHAR) * Header.Len);
+	Out[Header.Len] = '\0';
+}
+
+void FNameEntry::CopyUnterminatedName(WIDECHAR* Out) const
+{
+    FPlatformMemory::Memcpy(Out, WideName, sizeof(WIDECHAR) * Header.Len);
+	Out[Header.Len] = '\0';
+}
+
+void FNameEntry::GetAnsiName(ANSICHAR(&Out)[NAME_SIZE]) const
+{
+    assert(!IsWide());
+    CopyUnterminatedName(Out);
+    Out[Header.Len] = '\0';
+}
+
+void FNameEntry::GetWideName(WIDECHAR(&Out)[NAME_SIZE]) const
+{
+    assert(IsWide());
+    CopyUnterminatedName(Out);
+    Out[Header.Len] = '\0';
+}
+*/
+
+/*-----------------------------------------------------------------------------
+	FName statics.
+-----------------------------------------------------------------------------*/
+
+/*
+FNameEntry const* FName::GetEntry(FNameEntryId Id)
+{
+	// Public interface, recurse to the actual string entry if necessary
+	return ResolveEntryRecursive(Id);
+}
+
+#if WITH_CASE_PRESERVING_NAME
+FNameEntryId FName::GetComparisonIdFromDisplayId(FNameEntryId DisplayId)
+{
+	return GetEntry(DisplayId)->ComparisonId;
+}
+#endif
+
+// Resolve the entry directly referred to by LookupId
+const FNameEntry* FName::ResolveEntry(FNameEntryId LookupId)
+{
+	return &GetNamePool().Resolve(LookupId);
+}
+
+// Recursively resolve through the entry referred to by LookupId to reach the allocated string entry, in the case of UE_FNAME_OUTLINE_NUMBER=1
+const FNameEntry* FName::ResolveEntryRecursive(FNameEntryId LookupId)
+{
+	const FNameEntry* Entry = ResolveEntry(LookupId);
+#if UE_FNAME_OUTLINE_NUMBER
+	if (Entry->Header.Len == 0)
+	{
+		return ResolveEntry(Entry->GetNumberedName().Id); // Should only ever recurse one level
+	}
+	else
+#endif
+	{
+		return Entry;
+	}
+}
+*/
+
+struct FNameHelper
+{
+	template <typename CharType>
+	static FName MakeFName(const CharType* Str)
+	{
+		if constexpr (std::is_same_v<CharType, char>)
+		{
+			return MakeFName(Str, static_cast<uint32>(strlen(Str)));
+		}
+		else if constexpr (std::is_same_v<CharType, wchar_t>)
+		{
+			return MakeFName(Str, static_cast<uint32>(wcslen(Str)));
+		}
+		else
+		{
+			static_assert(false, "Invalid Character type");
+			return {};
+		}
+	}
+
+	template <typename CharType>
+	static FName MakeFName(const CharType* Char, uint32 Len)
+	{
+		// 문자열의 길이가 NAME_SIZE를 초과하면 None 반환
+		if (Len >= NAME_SIZE)
+		{
+			return {};
+		}
+
+		const FNameEntryId DisplayId = FNamePool::Get().Store({ Char, Len });
+		UE_LOG("NumEntries in FNamePool: %d", FNamePool::Get().NumEntries())
+
+		FName Result;
+		Result.DisplayIndex = DisplayId.Value;
+		Result.ComparisonIndex = ResolveComparisonId(DisplayId).Value;
+		return Result;
+	}
+
+	static FNameEntryId ResolveComparisonId(FNameEntryId DisplayId)
+	{
+		if (DisplayId.IsNone())
+		{
+			return {};
+		}
+		return FNamePool::Get().Resolve(DisplayId.Value).ComparisonId;
+	}
+};
+
+FName::FName(const WIDECHAR* Name)
+	: FName(FNameHelper::MakeFName(Name))
+{}
+
+FName::FName(const ANSICHAR* Name)
+	: FName(FNameHelper::MakeFName(Name))
+{}
+
+FName::FName(const FString& Name)
+	: FName(FNameHelper::MakeFName(*Name, Name.Len()))
+{}
+
+FString FName::ToString() const
+{
+	if (DisplayIndex == 0 && ComparisonIndex == 0)
+	{
+		return { TEXT("None") };
+	}
+
+	//TODO: FString이 WIDECHAR를 지원할 수 있도록 수정
+	FNameEntry Entry = FNamePool::Get().Resolve(DisplayIndex);
+	return {
+		//Entry.Header.bIsWide ? Entry.WideName : Entry.AnsiName
+		Entry.AnsiName
+	};
+}

--- a/Engine/Source/CoreUObject/Name.h
+++ b/Engine/Source/CoreUObject/Name.h
@@ -1,0 +1,3 @@
+﻿#pragma once
+
+struct FNameEntryId;

--- a/Engine/Source/CoreUObject/NameTypes.h
+++ b/Engine/Source/CoreUObject/NameTypes.h
@@ -1,0 +1,298 @@
+﻿#pragma once
+// There is only FName right now, Can be expanded to include other name types
+
+#include "HAL/PlatformType.h"
+#include "Container/String.h"
+
+/*----------------------------------------------------------------------------
+	Definitions.
+----------------------------------------------------------------------------*/
+
+/**
+ * FName에 대소문자 구분을 지원할지 여부 (기본: 지원)
+ * FName에 추가적인 NAME_INDEX 변수를 추가합니다.
+ * 여전히 ToString()은 FName::Init에 전달된 정확한 문자열을 반환합니다. (FNames가 최종 사용자에게 표시되는 경우 유용)
+ * Runtime에는 비활성화되어 있습니다. (Unreal Engine 기준)
+ */
+#ifndef WITH_CASE_PRESERVING_NAME
+#define WITH_CASE_PRESERVING_NAME 1
+#endif
+
+//@note: 대부분의 경우 FName에 저장하므로 따로 구현하지 않았습니다..!
+ // Fname의 숫자 부분을 NameTable에 저장할지 FName 인스턴스에 저장할지 여부 (기본: 0, FName에 저장)
+ // NameTable에 저장하면 전체적으로 메모리를 절약할 수 있지만 새로운 숫자 접미사는 고유한 문자열처럼 작용하여 NameTable이 커집니다.
+#ifndef UE_FNAME_OUTLINE_NUMBER
+#define UE_FNAME_OUTLINE_NUMBER 0
+#endif // UE_FNAME_OUTLINE_NUMBER
+
+/** FName에 저장될 수 있는 최대 길이 (공백문자 포함) */
+enum { NAME_SIZE = 256 };//1024 };
+
+/** Opaque id to a deduplicated name */
+struct FNameEntryId {
+//private:
+	uint32 Value; // 비교를 위한 문자열의 Hash
+
+public:
+	FNameEntryId() : Value(0) {}	// Default값은 NAME_None임
+	FNameEntryId(uint32 InValue) : Value(InValue) {}	//TODO: explicit 키워드 추가
+
+	bool IsNone() const	{ return Value == 0; }
+
+	bool operator==(FNameEntryId Rhs) const { return Value == Rhs.Value; }
+	bool operator!=(FNameEntryId Rhs) const { return Value != Rhs.Value; }
+
+	explicit operator bool() const { return Value != 0; }	// FNameEntryId가 0(NAME_None)이 아닌 경우 true 반환
+
+	// 현재 Value가 Public이어서 사용하지 않는 함수임
+	//@TODO: FNameEntryID를 왜 이렇게 구현했는지 이해해보기
+	/** Get process specific integer */
+	uint32 ToUnstableInt() const { return Value; }
+
+	/** Create from unstable int produced by this process */
+	static FNameEntryId FromUnstableInt(uint32 UnstableInt)
+	{
+		FNameEntryId Id;
+		Id.Value = UnstableInt;
+		return Id;
+	}
+};
+
+/**
+ * Legacy typedef - this is no longer an index
+ *
+ * Use GetTypeHash(FName) or GetTypeHash(FNameEntryId) for hashing
+ * To compare with ENames use FName(EName) or FName::ToEName() instead
+ */
+typedef FNameEntryId NAME_INDEX;
+
+/** Externally, the instance number to represent no instance number is NAME_NO_NUMBER,
+	but internally, we add 1 to indices, so we use this #define internally for
+	zero'd memory initialization will still make NAME_None as expected */
+#define NAME_NO_NUMBER_INTERNAL	0
+
+enum class ENameCase : uint8
+{
+	CaseSensitive,	// 대소문자 구분
+	IgnoreCase,		// 대소문자 무시
+};
+
+/** Enumeration for finding name. */
+//enum EFindName
+//{
+//	/**
+//	* Find a name; return 0/NAME_None/FName() if it doesn't exist.
+//	* When UE_FNAME_OUTLINE_NUMBER is set, we search for the exact name including the number suffix.
+//	* Otherwise we search only for the string part.
+//	*/
+//	FNAME_Find,
+//
+//	/** Find a name or add it if it doesn't exist. */
+//	FNAME_Add
+//};
+
+/*----------------------------------------------------------------------------
+	FNameEntry.
+----------------------------------------------------------------------------*/
+
+/** Entry에 들어갈 Name 정보 */
+struct FNameEntryHeader
+{
+	uint16 bIsWide : 1;	// wchar 여부
+#if WITH_CASE_PRESERVING_NAME
+	uint16 Len : 15;	// FName의 길이 0 ~ 32767 (2^16 - 1)
+#else
+	static constexpr inline uint32 ProbeHashBits = 5;
+	uint16 LowercaseProbeHash : ProbeHashBits;
+	uint16 Len : 10;
+#endif
+};
+
+/**
+ * FNameEntry는 FNamePool에 저장되는 실제 문자열 데이터입니다.
+ * 고유한 문자열과 그 문자열의 인스턴스 번호를 관리합니다.
+ */
+struct FNameEntry {
+#if WITH_CASE_PRESERVING_NAME
+	FNameEntryId ComparisonId;	// 비교를 위한 Hash
+#endif
+	FNameEntryHeader Header;	// 문자열 정보
+
+	// Unaligned to reduce alignment waste for non-numbered entries
+	struct FNumberedData
+	{
+#if UE_FNAME_OUTLINE_NUMBER	
+#if WITH_CASE_PRESERVING_NAME // ComparisonId is 4B-aligned, 4B-align Id/Number by 2B pad after 2B Header
+		uint8 Pad[sizeof(Header) % alignof(decltype(ComparisonId))];
+#endif						
+		uint8 Id[sizeof(FNameEntryId)];
+		uint8 Number[sizeof(uint32)];
+#endif // UE_FNAME_OUTLINE_NUMBER	
+	};
+
+	union
+	{
+		ANSICHAR			AnsiName[NAME_SIZE];
+		WIDECHAR			WideName[NAME_SIZE];
+		//FNumberedData		NumberedName;
+	};
+
+private:
+	//FNameEntry(const FNameEntry&) = delete;
+	//FNameEntry(FNameEntry&&) = delete;
+	//FNameEntry& operator=(const FNameEntry&) = delete;
+	//FNameEntry& operator=(FNameEntry&&) = delete;
+
+public:
+	FORCEINLINE bool IsWide() const { return Header.bIsWide; }
+	FORCEINLINE int32 GetNameLength() const { return Header.Len; }
+/*
+#if UE_FNAME_OUTLINE_NUMBER
+	FORCEINLINE bool IsNumbered() const { return Header.Len == 0; }
+#else
+	FORCEINLINE bool IsNumbered() const { return false; }
+#endif
+*/
+	/** Copy null-terminated name to TCHAR buffer without allocating. */
+	void GetName(TCHAR(&OutName)[NAME_SIZE]) const;
+
+	/** Copy null-terminated name to ANSICHAR buffer without allocating. Entry must not be wide. */
+	void GetAnsiName(ANSICHAR(&OutName)[NAME_SIZE]) const;
+
+	/** Copy null-terminated name to WIDECHAR buffer without allocating. Entry must be wide. */
+	void GetWideName(WIDECHAR(&OutName)[NAME_SIZE]) const;
+
+//private:
+	void StoreName(const ANSICHAR* InName, uint32 Len);
+	void StoreName(const WIDECHAR* InName, uint32 Len);
+	//void CopyUnterminatedName(ANSICHAR* OutName) const;
+	//void CopyUnterminatedName(WIDECHAR* OutName) const;
+
+};
+
+
+/**
+ * world에서 사용 가능한 Public Name입니다.\n
+ * '고유 문자열 테이블의 인덱스'와 '인스턴스 번호'의 조합으로 저장됩니다.\n
+ * 대소문자 구분은 하지 않지만, 대소문자를 보존합니다. (WITH_CASE_PRESERVING_NAME이 1인 경우)
+ */
+class FName {
+	friend struct FNameHelper;
+//TODO: uint32를 FNameEntryId로 변경
+//private:
+	uint32			ComparisonIndex;	// 비교를 위한 Hash
+#if !UE_FNAME_OUTLINE_NUMBER
+	uint32			Number;			// 숫자 부분 (인스턴스 번호)
+#endif// ! //UE_FNAME_OUTLINE_NUMBER
+#if WITH_CASE_PRESERVING_NAME
+	uint32			DisplayIndex;	// 원본 문자열의 Hash
+#endif // WITH_CASE_PRESERVING_NAME
+
+public:
+	FNameEntryId GetComparisonIndex() const { return ComparisonIndex; }
+	FNameEntryId GetDisplayIndex() const { return DisplayIndex; }
+	FString ToString() const;
+
+	FName(const WIDECHAR* Name);
+	FName(const ANSICHAR* Name);
+	FName(const FString& Name);
+
+	bool operator==(const FName& Other) const {
+		return ComparisonIndex == Other.ComparisonIndex;
+		//return ComparisonIndex.ToUnstableInt() == Other.ComparisonIndex.ToUnstableInt();
+	}
+
+	//explicit FName(FNameEntryId InComparisonIndex, uint32 InNumber)
+	//	: ComparisonIndex(InComparisonIndex), Number(InNumber) {
+	//}
+
+	/**
+	 * Create an FName from its component parts
+	 * Only call this if you *really* know what you're doing
+	 */
+	//FORCEINLINE FName(FNameEntryId InComparisonIndex, FNameEntryId InDisplayIndex, int32 InNumber)
+	//	: FName(CreateNumberedNameIfNecessary(InComparisonIndex, InDisplayIndex, InNumber))
+	//{
+	//}
+
+
+//#if WITH_CASE_PRESERVING_NAME
+//	static FNameEntryId GetComparisonIdFromDisplayId(FNameEntryId DisplayId);
+//#else
+//	static FNameEntryId GetComparisonIdFromDisplayId(FNameEntryId DisplayId) { return DisplayId; }
+//#endif
+
+	/**
+	 * Default constructor, initialized to None
+	 */
+	FName() : DisplayIndex(0), ComparisonIndex(0) {}
+//	FORCEINLINE FName()
+//#if !UE_FNAME_OUTLINE_NUMBER
+//		: Number(NAME_NO_NUMBER_INTERNAL)
+//#endif //!UE_FNAME_OUTLINE_NUMBER
+//	{}
+
+	/*
+	static FNameEntry const* GetEntry(FNameEntryId Id);
+
+	// Resolve the entry directly referred to by LookupId
+	static const FNameEntry* ResolveEntry(FNameEntryId LookupId);
+	// Recursively resolve through the entry referred to by LookupId to reach the allocated string entry, in the case of UE_FNAME_OUTLINE_NUMBER=1
+	static const FNameEntry* ResolveEntryRecursive(FNameEntryId LookupId);
+
+	FORCEINLINE static FName CreateNumberedNameIfNecessary(FNameEntryId ComparisonId, FNameEntryId DisplayId, int32 Number)
+	{
+#if UE_FNAME_OUTLINE_NUMBER
+		if (Number != NAME_NO_NUMBER_INTERNAL)
+		{
+			// We need to store a new entry in the name table
+			return CreateNumberedName(ComparisonId, DisplayId, Number);
+		}
+		// Otherwise we can just set the index members
+#endif
+		FName Out;
+		Out.ComparisonIndex = ComparisonId;
+#if WITH_CASE_PRESERVING_NAME
+		Out.DisplayIndex = DisplayId;
+#endif
+#if !UE_FNAME_OUTLINE_NUMBER
+		Out.Number = Number;
+#endif
+		return Out;
+	}
+	*/
+};
+
+/*
+class FDisplayNameEntryId
+{
+public:
+	FDisplayNameEntryId() : FDisplayNameEntryId(FName()) {}
+	explicit FDisplayNameEntryId(FName Name) : FDisplayNameEntryId(Name.GetDisplayIndex(), Name.GetComparisonIndex()) {}
+	FORCEINLINE FName ToName(uint32 Number) const { return FName(GetComparisonId(), GetDisplayId(), Number); }
+
+private:
+#if WITH_CASE_PRESERVING_NAME
+	static constexpr uint32 DifferentIdsFlag = 1u << 31;
+	static constexpr uint32 DisplayIdMask = ~DifferentIdsFlag;
+
+	uint32 Value = 0;
+
+	FDisplayNameEntryId(FNameEntryId Id, FNameEntryId CmpId) : Value(Id.ToUnstableInt() | (Id != CmpId) * DifferentIdsFlag) {}
+	FORCEINLINE bool SameIds() const { return (Value & DifferentIdsFlag) == 0; }
+	FORCEINLINE FNameEntryId GetDisplayId() const { return FNameEntryId::FromUnstableInt(Value & DisplayIdMask); }
+	FORCEINLINE FNameEntryId GetComparisonId() const { return SameIds() ? GetDisplayId() : FName::GetComparisonIdFromDisplayId(GetDisplayId()); }
+	friend bool operator==(FDisplayNameEntryId A, FDisplayNameEntryId B) { return A.Value == B.Value; }
+#else
+	FNameEntryId Id;
+
+	FDisplayNameEntryId(FNameEntryId InId, FNameEntryId) : Id(InId) {}
+	FORCEINLINE FNameEntryId GetDisplayId() const { return Id; }
+	FORCEINLINE FNameEntryId GetComparisonId() const { return Id; }
+	friend bool operator==(FDisplayNameEntryId A, FDisplayNameEntryId B) { return A.Id == B.Id; }
+#endif
+	friend bool operator==(FNameEntryId A, FDisplayNameEntryId B) { return A == B.GetDisplayId(); }
+	friend bool operator==(FDisplayNameEntryId A, FNameEntryId B) { return A.GetDisplayId() == B; }
+	friend uint32 GetTypeHash(FDisplayNameEntryId InId) { return InId.GetDisplayId().ToUnstableInt(); }
+};
+*/

--- a/Engine/Source/CoreUObject/Object.h
+++ b/Engine/Source/CoreUObject/Object.h
@@ -1,5 +1,6 @@
 ﻿#pragma once
 
+#include "NameTypes.h"
 #include "Core/HAL/PlatformType.h"
 #include "AbstractClass/UClass.h"
 
@@ -14,7 +15,7 @@ private:
 	uint32 UUID = 0;
 	uint32 InternalIndex; // Index of GUObjectArray
 
-	FString NamePrivate;
+	FName NamePrivate;
 
 public:
 	UObject();
@@ -24,7 +25,7 @@ public:
 	uint32 GetUUID() const { return UUID; }
 	uint32 GetInternalIndex() const { return InternalIndex; }
 
-	FString GetName() const { return NamePrivate; }
+	FName GetName() const { return NamePrivate; }
 	void SetName(const FString& InName) { NamePrivate = InName; }
 
 public:


### PR DESCRIPTION
# 사용하는 것
FName 변수 선언, .ToString()으로 FString으로 변환
## FNamePool : Singleton
FNamePool::Get()으로 전역 접근 가능
## FString FName::ToString()
FNamePool::Get().Resolve(DisplayIndex)으로 NamePool에 기록된 원본 문자열을 가져온다 (Resolve가 문자열 가져오는 메서드)
## bool operator==(const FName& Other) const
return ComparisonIndex == Other.ComparisonIndex; 으로 해시 끼리 비교
## 해시
djb2 hash를 사용하였는데, UE에서는 구글의 CityHash를 사용하고 있었다.
## 문자 타입에 대응
template <typename CharType>을 이용해 들어오는 타입에 따라 대응함
std::is_same_v<CharType, char 혹은 wchar_t>로 분기 나눔
# 구조체들
### FNamePool    //문자열에 대한 해시 테이블
- TMap<uint32, FNameEntry> DisplayPool
- TMap<uint32, FNameEntry> ComparisonPool;

### FNameEntry    //글로벌 NameTable에 저장되는 중복없는 문자열과 문자열 정보, 해시값 <- FNAmeENtryAllocator로 꽉꽉 눌러 담게 된다
- FNameEntryId ComparisonId
- FNameEntryHeader Header
- union { ANSICHAR AnsiName[NAME_SIZE]; WIDECHAR WideName[NAME_SIZE] }

### FNameEntryId    //해시값
- uint32 Value

### FNameEntryHeader    //Name의 정보
- uint16 bIsWide : 1
- uint16 Len : 15

### FNameValue ( template < ENameCase Sensitivity > )    // 대소문자 여부에 따른 문자열
- FNameStringView Name
- uint32 Hash
- FNameEntryId ComparisonId

### FNameStringView    // 다양한 타입의 문자열을 담을 수 있는 인터페이스
- union { void* Data; ANSICHAR* Ansi; WIDECHAR* Wide; }
- uint32 Len;
- bool bIsWide;