### PR TITLE
Refactor/camera

### DIFF
--- a/Engine/Source/Core/Input/PlayerController.cpp
+++ b/Engine/Source/Core/Input/PlayerController.cpp
@@ -15,9 +15,9 @@ APlayerController::APlayerController()
 
 void APlayerController::HandleCameraMovement(float DeltaTime)
 {
-    if (bIsHandlingGizmo)
+    if (!APlayerInput::Get().GetMouseDown(true))
     {
-        //return;
+        return;
     }
     
 	//@TODO: ImGuiIO.WantCaptureMouse를 이용하여 UI 조작중에는 카메라 조작을 막아야함
@@ -26,22 +26,19 @@ void APlayerController::HandleCameraMovement(float DeltaTime)
     ACamera* Camera = FEditorManager::Get().GetCamera();
     FTransform CameraTransform = Camera->GetActorTransform();
 
-    if (APlayerInput::Get().GetMouseDown(true))
-    {
-        // Last Frame Mouse Position
-        int32 DeltaX = 0;
-        int32 DeltaY = 0;
-        APlayerInput::Get().GetMouseDelta(DeltaX, DeltaY);
+    // Look
+    int32 DeltaX = 0;
+    int32 DeltaY = 0;
+    APlayerInput::Get().GetMouseDelta(DeltaX, DeltaY);
         
-        FVector NewRotation = CameraTransform.GetRotation().GetEuler();
-        NewRotation.Y += MouseSensitivity * static_cast<float>(DeltaY) * DeltaTime; // Pitch
-        NewRotation.Z += MouseSensitivity * static_cast<float>(DeltaX) * DeltaTime; // Yaw
+    FVector NewRotation = CameraTransform.GetRotation().GetEuler();
+    NewRotation.Y += MouseSensitivity * static_cast<float>(DeltaY) * DeltaTime; // Pitch
+    NewRotation.Z += MouseSensitivity * static_cast<float>(DeltaX) * DeltaTime; // Yaw
 
-        NewRotation.Y = FMath::Clamp(NewRotation.Y, -Camera->MaxYDegree, Camera->MaxYDegree);
-        CameraTransform.SetRotation(NewRotation);
-    }
-
-    // Camera Speed //
+    NewRotation.Y = FMath::Clamp(NewRotation.Y, -Camera->MaxYDegree, Camera->MaxYDegree);
+    CameraTransform.SetRotation(NewRotation);
+    
+    // Move
     int32 MouseWheel = APlayerInput::Get().GetMouseWheelDelta();
     CurrentSpeed += static_cast<float>(MouseWheel) * 0.001f;
     CurrentSpeed = FMath::Clamp(CurrentSpeed, MinSpeed, MaxSpeed);

--- a/Engine/Source/Core/Input/PlayerController.cpp
+++ b/Engine/Source/Core/Input/PlayerController.cpp
@@ -15,16 +15,24 @@ APlayerController::APlayerController()
 
 void APlayerController::HandleCameraMovement(float DeltaTime)
 {
+    if (bUiCaptured)
+    {
+        return;
+    }
+    
     if (!APlayerInput::Get().IsMouseDown(true))
     {
         if (APlayerInput::Get().IsMouseReleased(true))
         {
+            /**
+             * ShowCursor 함수는 참조 카운트를 하므로, 정확한 횟수만큼 Show 및 Hide 하지 않으면
+             * 의도대로 작동하지 않는 문제가 발생함으로 매우 주의해야 함.
+             */
             ShowCursor(true);
         }
         return;
     }
     
-	//@TODO: ImGuiIO.WantCaptureMouse를 이용하여 UI 조작중에는 카메라 조작을 막아야함
     FVector NewVelocity(0, 0, 0);
 
     ACamera* Camera = FEditorManager::Get().GetCamera();
@@ -110,7 +118,24 @@ void APlayerController::HandleGizmoMovement(float DeltaTime)
 
 void APlayerController::ProcessPlayerInput(float DeltaTime)
 {
+    if (bUiInput)
+    {
+        if (APlayerInput::Get().IsMouseDown(true) || APlayerInput::Get().IsMouseDown(false))
+        {
+            bUiCaptured = true;
+        }
+        return;
+    }
+    if (bUiCaptured)
+    {
+        if (!APlayerInput::Get().IsMouseDown(true) && !APlayerInput::Get().IsMouseDown(false))
+        {
+            bUiCaptured = false;
+        }
+        return;
+    }
+    
     // TODO: 기즈모 조작시에는 카메라 입력 무시
-    // HandleGizmoMovement(DeltaTime);
+    // HandleGizmoMovement(DeltaTime); // TODO: 의미없는 함수인듯
     HandleCameraMovement(DeltaTime);
 }

--- a/Engine/Source/Core/Input/PlayerController.cpp
+++ b/Engine/Source/Core/Input/PlayerController.cpp
@@ -6,59 +6,57 @@
 #include "Core/Math/Plane.h"
 #include "Engine/GameFrameWork/Camera.h"
 
-APlayerController::APlayerController() {
-
-}
+APlayerController::APlayerController()
+    : CurrentSpeed(3.f)
+    , MaxSpeed(10.f)
+    , MinSpeed(0.1f)
+    , MouseSensitivity(10.f)
+{}
 
 void APlayerController::HandleCameraMovement(float DeltaTime) {
 
 	//@TODO: ImGuiIO.WantCaptureMouse를 이용하여 UI 조작중에는 카메라 조작을 막아야함
     FVector NewVelocity(0, 0, 0);
 
-    if (APlayerInput::Get().IsPressedMouse(true) == false)
-    {
-        // Camera->SetVelocity(NewVelocity);
-        return;
-    }
-
     ACamera* Camera = FEditorManager::Get().GetCamera();
+    FTransform CameraTransform = Camera->GetActorTransform();
+
+    if (APlayerInput::Get().IsPressedMouse(true))
+    {
+        // Last Frame Mouse Position
+        FVector MousePrePos = APlayerInput::Get().GetMousePrePos();
+        FVector MousePos = APlayerInput::Get().GetMousePos();
+        FVector DeltaPos = MousePos - MousePrePos;
+
+        FVector NewRotation = CameraTransform.GetRotation().GetEuler();
+        NewRotation.Y += MouseSensitivity * DeltaPos.Y * DeltaTime; // Pitch
+        NewRotation.Z += MouseSensitivity * DeltaPos.X * DeltaTime; // Yaw
+
+        NewRotation.Y = FMath::Clamp(NewRotation.Y, -Camera->MaxYDegree, Camera->MaxYDegree);
+        CameraTransform.SetRotation(NewRotation);
+    }
 
     // Camera Speed //
     float MouseWheel = APlayerInput::Get().GetMouseWheel();
-
-    float CameraSpeed = Camera->CameraSpeed;
-    CameraSpeed += MouseWheel * 0.1f;
-    CameraSpeed = FMath::Clamp(CameraSpeed, 0.1f, 5.0f);
-
-    Camera->CameraSpeed = CameraSpeed;
+    CurrentSpeed += MouseWheel * 0.1f;
+    CurrentSpeed = FMath::Clamp(CurrentSpeed, MinSpeed, MaxSpeed);
 
     APlayerInput::Get().SetMouseWheel(0.0f);    // Reset MouseWheel After Set Camera Speed
 
-    // Last Frame Mouse Position
-    FVector MousePrePos = APlayerInput::Get().GetMousePrePos();
-    FVector MousePos = APlayerInput::Get().GetMousePos();
-    FVector DeltaPos = MousePos - MousePrePos;
-    //FQuat CameraRot = FEditorManager::Get().GetCamera()->GetActorTransform().GetRotation();
-
-    FTransform CameraTransform = Camera->GetActorTransform();
-
-    FVector TargetRotation = CameraTransform.GetRotation().GetEuler();
-    TargetRotation.Y += Camera->CameraSpeed * DeltaPos.Y * DeltaTime * 2.0f;    //@TODO: CameraRotaionSpeed를 나중에 조절할 수 있도록 수정
-    TargetRotation.Z += Camera->CameraSpeed * DeltaPos.X * DeltaTime * 2.0f;
-
-    TargetRotation.Y = FMath::Clamp(TargetRotation.Y, -Camera->MaxYDegree, Camera->MaxYDegree);
-    CameraTransform.SetRotation(TargetRotation);
-
-    if (APlayerInput::Get().IsPressedKey(EKeyCode::A)) {
+    if (APlayerInput::Get().IsPressedKey(EKeyCode::A))
+    {
         NewVelocity -= Camera->GetRight();
     }
-    if (APlayerInput::Get().IsPressedKey(EKeyCode::D)) {
+    if (APlayerInput::Get().IsPressedKey(EKeyCode::D))
+    {
         NewVelocity += Camera->GetRight();
     }
-    if (APlayerInput::Get().IsPressedKey(EKeyCode::W)) {
+    if (APlayerInput::Get().IsPressedKey(EKeyCode::W))
+    {
         NewVelocity += Camera->GetForward();
     }
-    if (APlayerInput::Get().IsPressedKey(EKeyCode::S)) {
+    if (APlayerInput::Get().IsPressedKey(EKeyCode::S))
+        {
         NewVelocity -= Camera->GetForward();
     }
     if (APlayerInput::Get().IsPressedKey(EKeyCode::Q))
@@ -74,10 +72,8 @@ void APlayerController::HandleCameraMovement(float DeltaTime) {
         NewVelocity = NewVelocity.GetSafeNormal();
     }
 
-    //회전이랑 마우스클릭 구현 카메라로 해야할듯?
-    CameraTransform.Translate(NewVelocity * DeltaTime * Camera->CameraSpeed);
+    CameraTransform.Translate(NewVelocity * DeltaTime * CurrentSpeed);
     Camera->SetActorTransform(CameraTransform);
-    // FCamera::Get().SetVelocity(NewVelocity);
 }
 
 void APlayerController::HandleGizmoMovement(float DeltaTime)
@@ -94,8 +90,6 @@ void APlayerController::HandleGizmoMovement(float DeltaTime)
     {
         return;
     }
-
-
 }
 
 void APlayerController::ProcessPlayerInput(float DeltaTime) {

--- a/Engine/Source/Core/Input/PlayerController.cpp
+++ b/Engine/Source/Core/Input/PlayerController.cpp
@@ -17,7 +17,7 @@ void APlayerController::HandleCameraMovement(float DeltaTime)
 {
     if (bIsHandlingGizmo)
     {
-        return;
+        //return;
     }
     
 	//@TODO: ImGuiIO.WantCaptureMouse를 이용하여 UI 조작중에는 카메라 조작을 막아야함
@@ -102,6 +102,6 @@ void APlayerController::HandleGizmoMovement(float DeltaTime)
 void APlayerController::ProcessPlayerInput(float DeltaTime)
 {
     // TODO: 기즈모 조작시에는 카메라 입력 무시
-    HandleGizmoMovement(DeltaTime);
+    // HandleGizmoMovement(DeltaTime);
     HandleCameraMovement(DeltaTime);
 }

--- a/Engine/Source/Core/Input/PlayerController.cpp
+++ b/Engine/Source/Core/Input/PlayerController.cpp
@@ -9,14 +9,18 @@
 APlayerController::APlayerController()
     : CurrentSpeed(3.f)
     , MaxSpeed(10.f)
-    , MinSpeed(0.1f)
+    , MinSpeed(1.0f)
     , MouseSensitivity(10.f)
 {}
 
 void APlayerController::HandleCameraMovement(float DeltaTime)
 {
-    if (!APlayerInput::Get().GetMouseDown(true))
+    if (!APlayerInput::Get().IsMouseDown(true))
     {
+        if (APlayerInput::Get().IsMouseReleased(true))
+        {
+            ShowCursor(true);
+        }
         return;
     }
     
@@ -37,33 +41,41 @@ void APlayerController::HandleCameraMovement(float DeltaTime)
 
     NewRotation.Y = FMath::Clamp(NewRotation.Y, -Camera->MaxYDegree, Camera->MaxYDegree);
     CameraTransform.SetRotation(NewRotation);
+
+    if (APlayerInput::Get().IsMousePressed(true))
+    {
+        // Press 이벤트 발생시 커서 위치를 캐싱하여 해당 위치로 커서를 고정시킴.
+        APlayerInput::Get().CacheCursorPosition();
+        ShowCursor(false);
+    }
+    APlayerInput::Get().FixMouseCursor();
     
     // Move
     int32 MouseWheel = APlayerInput::Get().GetMouseWheelDelta();
-    CurrentSpeed += static_cast<float>(MouseWheel) * 0.001f;
+    CurrentSpeed += static_cast<float>(MouseWheel) * 0.005f;
     CurrentSpeed = FMath::Clamp(CurrentSpeed, MinSpeed, MaxSpeed);
 
-    if (APlayerInput::Get().GetKeyDown(DirectX::Keyboard::Keys::A))
+    if (APlayerInput::Get().IsKeyDown(DirectX::Keyboard::Keys::A))
     {
         NewVelocity -= Camera->GetRight();
     }
-    if (APlayerInput::Get().GetKeyDown(DirectX::Keyboard::Keys::D))
+    if (APlayerInput::Get().IsKeyDown(DirectX::Keyboard::Keys::D))
     {
         NewVelocity += Camera->GetRight();
     }
-    if (APlayerInput::Get().GetKeyDown(DirectX::Keyboard::Keys::W))
+    if (APlayerInput::Get().IsKeyDown(DirectX::Keyboard::Keys::W))
     {
         NewVelocity += Camera->GetForward();
     }
-    if (APlayerInput::Get().GetKeyDown(DirectX::Keyboard::Keys::S))
+    if (APlayerInput::Get().IsKeyDown(DirectX::Keyboard::Keys::S))
         {
         NewVelocity -= Camera->GetForward();
     }
-    if (APlayerInput::Get().GetKeyDown(DirectX::Keyboard::Keys::Q))
+    if (APlayerInput::Get().IsKeyDown(DirectX::Keyboard::Keys::Q))
     {
         NewVelocity -= {0.0f, 0.0f, 1.0f};
     }
-    if (APlayerInput::Get().GetKeyDown(DirectX::Keyboard::Keys::E))
+    if (APlayerInput::Get().IsKeyDown(DirectX::Keyboard::Keys::E))
     {
         NewVelocity += {0.0f, 0.0f, 1.0f};
     }
@@ -80,7 +92,7 @@ void APlayerController::HandleGizmoMovement(float DeltaTime)
 {
     bIsHandlingGizmo = false;
     
-    if (APlayerInput::Get().IsPressedMouse(false) == false)
+    if (APlayerInput::Get().IsMousePressed(false) == false)
     {
         return;
     }

--- a/Engine/Source/Core/Input/PlayerController.h
+++ b/Engine/Source/Core/Input/PlayerController.h
@@ -6,7 +6,7 @@ class APlayerController : public TSingleton<APlayerController>
 {
 	// TODO: 카메라는 플레이어 컨트롤러가 가지고있어야 함.
 	
-	public :
+public :
 	APlayerController();
 
 	void ProcessPlayerInput(float DeltaTime);

--- a/Engine/Source/Core/Input/PlayerController.h
+++ b/Engine/Source/Core/Input/PlayerController.h
@@ -23,6 +23,10 @@ public :
 	float GetMouseSensitivity() const { return MouseSensitivity; }
 	void SetMouseSensitivity(float InSensitivity) { MouseSensitivity = InSensitivity;}
 
+	// TODO: 함수랑 변수 이름 맘에 안듬
+	bool IsUiInput() const { return bUiInput; }
+	void SetIsUiInput(bool bInUiInput) { bUiInput = bInUiInput; }
+	
 protected:
 	float CurrentSpeed;
 	float MaxSpeed;
@@ -31,4 +35,7 @@ protected:
 	float MouseSensitivity;
 
 	bool bIsHandlingGizmo;
+
+	bool bUiInput = false;
+	bool bUiCaptured = false;
 };

--- a/Engine/Source/Core/Input/PlayerController.h
+++ b/Engine/Source/Core/Input/PlayerController.h
@@ -2,7 +2,10 @@
 
 #include "Core/AbstractClass/Singleton.h"
 
-class APlayerController : public TSingleton<APlayerController> {
+class APlayerController : public TSingleton<APlayerController>
+{
+	// TODO: 카메라는 플레이어 컨트롤러가 가지고있어야 함.
+	
 	public :
 	APlayerController();
 
@@ -10,4 +13,20 @@ class APlayerController : public TSingleton<APlayerController> {
 
 	void HandleCameraMovement(float DeltaTime);
 	void HandleGizmoMovement(float DeltaTime);
+
+	float GetCurrentSpeed() const { return CurrentSpeed; }
+	float GetMaxSpeed() const { return MaxSpeed; }
+	float GetMinSpeed() const { return MinSpeed; }
+
+	void SetCurrentSpeed(float InSpeed) { CurrentSpeed = InSpeed; }
+
+	float GetMouseSensitivity() const { return MouseSensitivity; }
+	void SetMouseSensitivity(float InSensitivity) { MouseSensitivity = InSensitivity;}
+
+protected:
+	float CurrentSpeed;
+	float MaxSpeed;
+	float MinSpeed;
+
+	float MouseSensitivity;
 };

--- a/Engine/Source/Core/Input/PlayerController.h
+++ b/Engine/Source/Core/Input/PlayerController.h
@@ -29,4 +29,6 @@ protected:
 	float MinSpeed;
 
 	float MouseSensitivity;
+
+	bool bIsHandlingGizmo;
 };

--- a/Engine/Source/Core/Input/PlayerInput.cpp
+++ b/Engine/Source/Core/Input/PlayerInput.cpp
@@ -25,8 +25,6 @@ void APlayerInput::UpdateInput()
     // 마우스 상태 가져오기
     auto MouseState = Mouse->GetState();
     MouseTracker.Update(MouseState);
-    int X = MouseState.x; // 윈도우에 상대적
-    int Y = MouseState.y;
 
     PrevMouseState = CurrentMouseState;
     
@@ -34,8 +32,8 @@ void APlayerInput::UpdateInput()
     CurrentMouseState.RightDown = MouseState.rightButton;
     CurrentMouseState.MiddleDown = MouseState.middleButton;
     CurrentMouseState.Wheel = MouseState.scrollWheelValue;
-    CurrentMouseState.X = X;
-    CurrentMouseState.Y = Y;
+    CurrentMouseState.X = MouseState.x; // 윈도우에 상대적
+    CurrentMouseState.Y = MouseState.y; // 윈도우에 상대적
 }
 
 bool APlayerInput::IsPressedKey(DirectX::Keyboard::Keys InKey) const

--- a/Engine/Source/Core/Input/PlayerInput.cpp
+++ b/Engine/Source/Core/Input/PlayerInput.cpp
@@ -46,6 +46,16 @@ bool APlayerInput::IsKeyPressed(DirectX::Keyboard::Keys InKey) const
     return KeyboardTracker.pressed.IsKeyDown(InKey);
 }
 
+bool APlayerInput::IsKeyReleased(DirectX::Keyboard::Keys InKey) const
+{
+    return KeyboardTracker.released.IsKeyDown(InKey);
+}
+
+bool APlayerInput::IsKeyDown(DirectX::Keyboard::Keys InKey) const
+{
+    return Keyboard->GetState().IsKeyDown(InKey);
+}
+
 bool APlayerInput::IsMousePressed(bool isRight) const
 {
     if (isRight)
@@ -71,11 +81,6 @@ bool APlayerInput::IsMouseDown(bool isRight) const
         return CurrentMouseState.RightDown;
     }
     return CurrentMouseState.LeftDown;
-}
-
-bool APlayerInput::IsKeyDown(DirectX::Keyboard::Keys InKey) const
-{
-    return Keyboard->GetState().IsKeyDown(InKey);
 }
 
 void APlayerInput::GetMouseDelta(int32& OutX, int32& OutY) const

--- a/Engine/Source/Core/Input/PlayerInput.cpp
+++ b/Engine/Source/Core/Input/PlayerInput.cpp
@@ -22,13 +22,6 @@ void APlayerInput::UpdateInput()
     auto Kb = Keyboard->GetState();
     KeyboardTracker.Update(Kb);
 
-    if (Kb.Escape) {
-        OutputDebugStringA("ESC Pressed\n");
-    }
-    if (KeyboardTracker.pressed.Space) {
-        OutputDebugStringA("Space Pressed\n");
-    }
-
     // 마우스 상태 가져오기
     auto MouseState = Mouse->GetState();
     MouseTracker.Update(MouseState);
@@ -85,12 +78,12 @@ void APlayerInput::GetMousePosition(int32& OutX, int32& OutY) const
     OutY = CurrentMouseState.Y;
 }
 
-void APlayerInput::GetMousePositionNDC(int32& OutX, int32& OutY) const
+void APlayerInput::GetMousePositionNDC(float& OutX, float& OutY) const
 {
-    int32 HalfWidth = static_cast<int32>(WindowWidth) / 2;
-    int32 HalfHeight = static_cast<int32>(WindowHeight) / 2;
-    OutX = (CurrentMouseState.X - HalfWidth) / HalfWidth;
-    OutY = (CurrentMouseState.Y - HalfHeight) / HalfHeight * -1;
+    float HalfWidth = static_cast<float>(WindowWidth) / 2.f;
+    float HalfHeight = static_cast<float>(WindowHeight) / 2.f;
+    OutX = (static_cast<float>(CurrentMouseState.X) - HalfWidth) / HalfWidth;
+    OutY = (static_cast<float>(CurrentMouseState.Y) - HalfHeight) / HalfHeight * -1.f;
 }
 
 int32 APlayerInput::GetMouseWheel() const

--- a/Engine/Source/Core/Input/PlayerInput.cpp
+++ b/Engine/Source/Core/Input/PlayerInput.cpp
@@ -34,14 +34,19 @@ void APlayerInput::UpdateInput()
     CurrentMouseState.Wheel = MouseState.scrollWheelValue;
     CurrentMouseState.X = MouseState.x; // 윈도우에 상대적
     CurrentMouseState.Y = MouseState.y; // 윈도우에 상대적
+
+    POINT p;
+    GetCursorPos(&p);
+    CurrentMouseState.ScreenX = p.x;
+    CurrentMouseState.ScreenY = p.y;
 }
 
-bool APlayerInput::IsPressedKey(DirectX::Keyboard::Keys InKey) const
+bool APlayerInput::IsKeyPressed(DirectX::Keyboard::Keys InKey) const
 {
     return KeyboardTracker.pressed.IsKeyDown(InKey);
 }
 
-bool APlayerInput::IsPressedMouse(bool isRight) const
+bool APlayerInput::IsMousePressed(bool isRight) const
 {
     if (isRight)
     {
@@ -50,7 +55,16 @@ bool APlayerInput::IsPressedMouse(bool isRight) const
     return !PrevMouseState.LeftDown && CurrentMouseState.LeftDown;
 }
 
-bool APlayerInput::GetMouseDown(bool isRight) const
+bool APlayerInput::IsMouseReleased(bool isRight) const
+{
+    if (isRight)
+    {
+        return PrevMouseState.RightDown && !CurrentMouseState.RightDown;
+    }
+    return PrevMouseState.LeftDown && !CurrentMouseState.LeftDown;
+}
+
+bool APlayerInput::IsMouseDown(bool isRight) const
 {
     if (isRight)
     {
@@ -59,15 +73,15 @@ bool APlayerInput::GetMouseDown(bool isRight) const
     return CurrentMouseState.LeftDown;
 }
 
-bool APlayerInput::GetKeyDown(DirectX::Keyboard::Keys InKey) const
+bool APlayerInput::IsKeyDown(DirectX::Keyboard::Keys InKey) const
 {
     return Keyboard->GetState().IsKeyDown(InKey);
 }
 
 void APlayerInput::GetMouseDelta(int32& OutX, int32& OutY) const
 {
-    OutX = CurrentMouseState.X - PrevMouseState.X;
-    OutY = CurrentMouseState.Y - PrevMouseState.Y;
+    OutX = CurrentMouseState.ScreenX - PrevMouseState.ScreenX;
+    OutY = CurrentMouseState.ScreenY - PrevMouseState.ScreenY;
 }
 
 void APlayerInput::GetMousePosition(int32& OutX, int32& OutY) const
@@ -92,4 +106,25 @@ int32 APlayerInput::GetMouseWheel() const
 int32 APlayerInput::GetMouseWheelDelta() const
 {
     return CurrentMouseState.Wheel - PrevMouseState.Wheel;
+}
+
+void APlayerInput::CacheCursorPosition()
+{
+    /**
+     * PrevMouseState를 캐싱하는 이유:
+     *   윈도우 메시지를 통한 마우스 커서 위치 업데이트는 커서가 윈도우 창을 벗어나면 업데이트 되지 않음.
+     *   만약 커서가 빠르게 움직이고 있고, 캐싱해야할 시점에 커서가 윈도우를 벗어나면,
+     *   캐싱 값은 스크린 포지션이므로 윈도우 바깥의 위치를 캐싱하고, 그 위치에 커서를 고정함.
+     *   윈도우 바깥에 커서가 고정되니 포지션 델타값이 업데이트 되지 않아서 값이 유지되고, 시점에 지속적으로 회전하는 문제 발생.
+     *   따라서 커서가 윈도우를 벗어나지 않았던 이전 시점의 위치를 캐싱함으로써 위와 같은 문제 방지.
+     */
+    CachedMouseX = PrevMouseState.ScreenX;
+    CachedMouseY = PrevMouseState.ScreenY;
+}
+
+void APlayerInput::FixMouseCursor()
+{
+    CurrentMouseState.ScreenX = PrevMouseState.ScreenX;
+    CurrentMouseState.ScreenY = PrevMouseState.ScreenY;
+    SetCursorPos(CachedMouseX, CachedMouseY);
 }

--- a/Engine/Source/Core/Input/PlayerInput.h
+++ b/Engine/Source/Core/Input/PlayerInput.h
@@ -23,13 +23,15 @@ public:
 	 */
 	bool IsKeyPressed(DirectX::Keyboard::Keys InKey) const;
 
+	bool IsKeyReleased(DirectX::Keyboard::Keys InKey) const;
+
+	bool IsKeyDown(DirectX::Keyboard::Keys InKey) const;
+
 	bool IsMousePressed(bool isRight) const;
 
 	bool IsMouseReleased(bool isRight) const;
 	
 	bool IsMouseDown(bool isRight) const;
-
-	bool IsKeyDown(DirectX::Keyboard::Keys InKey) const;
 
 	void GetMouseDelta(int32& OutX, int32& OutY) const;
 

--- a/Engine/Source/Core/Input/PlayerInput.h
+++ b/Engine/Source/Core/Input/PlayerInput.h
@@ -3,192 +3,65 @@
 #include "Core/AbstractClass/Singleton.h"
 #include "Core/Math/Vector.h"
 
-/**
- * 윈도우 키 코드 열거형
- * @note https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
- */
-enum class EKeyCode : uint8_t
-{
-	Backspace = 0x08,
-	Tab = 0x09,
-	Enter = 0x0D,
-	Shift = 0x10,
-	Ctrl = 0x11,
-	Control = 0x11,
-	Alt = 0x12,
-	Pause = 0x13,
-	CapsLock = 0x14,
-	Esc = 0x1B,
-	Escape = 0x1B,
-	Space = 0x20,
-	PageUp = 0x21,
-	PageDown = 0x22,
-	End = 0x23,
-	Home = 0x24,
-	Left = 0x25,
-	Up = 0x26,
-	Right = 0x27,
-	Down = 0x28,
-	SnapShot = 0x2C,
-	PrintScreen = 0x2C,
-	Insert = 0x2D,
-	Delete = 0x2E,
-	_0 = 0x30,
-	_1 = 0x31,
-	_2 = 0x32,
-	_3 = 0x33,
-	_4 = 0x34,
-	_5 = 0x35,
-	_6 = 0x36,
-	_7 = 0x37,
-	_8 = 0x38,
-	_9 = 0x39,
-	A = 0x41,
-	B = 0x42,
-	C = 0x43,
-	D = 0x44,
-	E = 0x45,
-	F = 0x46,
-	G = 0x47,
-	H = 0x48,
-	I = 0x49,
-	J = 0x4A,
-	K = 0x4B,
-	L = 0x4C,
-	M = 0x4D,
-	N = 0x4E,
-	O = 0x4F,
-	P = 0x50,
-	Q = 0x51,
-	R = 0x52,
-	S = 0x53,
-	T = 0x54,
-	U = 0x55,
-	V = 0x56,
-	W = 0x57,
-	X = 0x58,
-	Y = 0x59,
-	Z = 0x5A,
-	Num0 = 0x60,
-	Num1 = 0x61,
-	Num2 = 0x62,
-	Num3 = 0x63,
-	Num4 = 0x64,
-	Num5 = 0x65,
-	Num6 = 0x66,
-	Num7 = 0x67,
-	Num8 = 0x68,
-	Num9 = 0x69,
-	NumMul = 0x6A,
-	NumAdd = 0x6B,
-	NumSub = 0x6D,
-	NumDot = 0x6E,
-	NumDiv = 0x6F,
-	F1 = 0x70,
-	F2 = 0x71,
-	F3 = 0x72,
-	F4 = 0x73,
-	F5 = 0x74,
-	F6 = 0x75,
-	F7 = 0x76,
-	F8 = 0x77,
-	F9 = 0x78,
-	F10 = 0x79,
-	F11 = 0x7A,
-	F12 = 0x7B,
-	F13 = 0x7C,
-	F14 = 0x7D,
-	F15 = 0x7E,
-	F16 = 0x7F,
-	F17 = 0x80,
-	F18 = 0x81,
-	F19 = 0x82,
-	F20 = 0x83,
-	F21 = 0x84,
-	F22 = 0x85,
-	F23 = 0x86,
-	F24 = 0x87,
-	NumLock = 0x90,
-	ScrollLock = 0x91,
-	LShift = 0xA0,
-	RShift = 0xA1,
-	LControl = 0xA2,
-	RControl = 0xA3,
-	LAlt = 0xA4,
-	RAlt = 0xA5,
-};
+#include "DirectXTK/Keyboard.h"
+#include "DirectXTK/Mouse.h"
+#include "DirectXTK/GamePad.h"
 
 class APlayerInput : public TSingleton<APlayerInput>
 {
 public:
 	APlayerInput();
 
-	/**
-	 * 키를 눌림 상태로 전환합니다. 
-	 */
-	void KeyDown(EKeyCode key);
-	void KeyOnceUp(EKeyCode key);
+	void SetWindowSize(uint32 InWidth, uint32 InHeight);
+
+	void UpdateInput();
 
 	/**
-	 * 키를 눌리지 않은 상태로 전환합니다.
-	 */
-	void KeyUp(EKeyCode key);
-
-	void SetMousePos();
-	void ExpireOnce();
-	
-	void HandleMouseInput(HWND hWnd, LPARAM lParam, bool isDown, bool isRight);
-	void HandleMouseWheel(WPARAM wParam);
-	
-	std::vector<EKeyCode> GetPressedKeys();
-
-	/**
-	 * 키가 눌려있는지 확인합니다.
-	 * @param key 감지 할 키
+	 * 키가 눌려있는지 확인.
+	 * @param InKey 감지 할 키
 	 * @return key의 눌림 여부
 	 */
-	[[nodiscard]] bool IsPressedKey(EKeyCode key) const;
+	bool IsPressedKey(DirectX::Keyboard::Keys InKey) const;
 
-	void MouseKeyDown(FVector MouseDownPoint, FVector WindowSize, int isRight);
-
-	void MouseKeyUp(FVector MouseUpPoint, FVector WindowSize, int isRight);
-	void PreProcessInput();
-	void TickPlayerInput();
-
-	bool IsPressedMouse(bool isRight) { return _mouse[isRight]; }
-
-	bool GetMouseDown(bool isRight) { return _onceMouse[isRight]; }
-
-	[[nodiscard]] bool GetKeyDown(EKeyCode KeyCode) const { return _onceKeys[static_cast<uint32>(KeyCode)];}
-
-	FVector GetMouseDownPos(int isRight) { return MouseKeyDownPos[isRight]; }
-
-	FVector GetMouseDownNDCPos(int isRight) { return MouseKeyDownNDCPos[isRight]; }
-
-	FVector GetMousePos() { return MousePos;}
-	FVector GetMouseNDCPos() { return MouseNDCPos;}
-	FVector GetMousePrePos() { return MousePrePos;}
-	float GetMouseWheel() { return MouseWheel; }
+	bool IsPressedMouse(bool isRight) const;
 	
-	FVector CalNDCPos(FVector MousePos, FVector WindowSize);
+	bool GetMouseDown(bool isRight) const;
 
-	void SetMousePrePos(FVector PMP) { MousePrePos = PMP;}
-	void SetMousePos(FVector MP){ SetMousePrePos(MousePos); MousePos = MP;}
-	void SetMouseNDCPos(FVector MNP) {MouseNDCPos = MNP;}
-	void SetMouseWheel(float MW) { MouseWheel = MW; }
+	bool GetKeyDown(DirectX::Keyboard::Keys InKey) const;
+
+	void GetMouseDelta(int32& OutX, int32& OutY) const;
+
+	// 윈도우 상대적인 마우스 위치 값
+	void GetMousePosition(int32& OutX, int32& OutY) const;
+
+	void GetMousePositionNDC(int32& OutX, int32& OutY) const;
+
+	int32 GetMouseWheel() const;
+
+	int32 GetMouseWheelDelta() const;
 	
 private:
-	// std::unordered_map<EKeyCode, std::unordered_set<void()>> InputHandlers; //인풋핸들러 각 오브젝트에서 키에 해당하는 함수를 할당한 다음 업데이트에서 눌린 키에 해당하는 함수 계속 돌려줘서 실행 
+	uint32 WindowWidth;
+	uint32 WindowHeight;
+	
+	std::unique_ptr<DirectX::Keyboard> Keyboard;
+	std::unique_ptr<DirectX::Mouse> Mouse;
+	std::unique_ptr<DirectX::GamePad> GamePad;
+	
+	// 이전의 입력 기록을 저장하여 상태 변화를 추적
+	DirectX::Keyboard::KeyboardStateTracker KeyboardTracker;
+	DirectX::Mouse::ButtonStateTracker MouseTracker;
 
-	bool _mouse[2]; //0이 좌클릭 1이 우클릭
-	bool _onceMouse[2];
-	bool _keys[256];
-	bool _onceKeys[256];
-	bool bIsBlockInput = false;
-	FVector MouseKeyDownPos[2];
-	FVector MouseKeyDownNDCPos[2];
-	FVector MousePrePos;
-	FVector MousePos;
-	FVector MouseNDCPos;
-	float MouseWheel = 0;
+	struct MouseState
+	{
+		bool LeftDown = false;
+		bool RightDown = false;
+		bool MiddleDown = false;
+		int32 Wheel = 0; // Delta
+		int32 X = 0;
+		int32 Y = 0;
+	};
+
+	MouseState PrevMouseState;
+	MouseState CurrentMouseState;
 };

--- a/Engine/Source/Core/Input/PlayerInput.h
+++ b/Engine/Source/Core/Input/PlayerInput.h
@@ -21,13 +21,15 @@ public:
 	 * @param InKey 감지 할 키
 	 * @return key의 눌림 여부
 	 */
-	bool IsPressedKey(DirectX::Keyboard::Keys InKey) const;
+	bool IsKeyPressed(DirectX::Keyboard::Keys InKey) const;
 
-	bool IsPressedMouse(bool isRight) const;
+	bool IsMousePressed(bool isRight) const;
+
+	bool IsMouseReleased(bool isRight) const;
 	
-	bool GetMouseDown(bool isRight) const;
+	bool IsMouseDown(bool isRight) const;
 
-	bool GetKeyDown(DirectX::Keyboard::Keys InKey) const;
+	bool IsKeyDown(DirectX::Keyboard::Keys InKey) const;
 
 	void GetMouseDelta(int32& OutX, int32& OutY) const;
 
@@ -39,6 +41,15 @@ public:
 	int32 GetMouseWheel() const;
 
 	int32 GetMouseWheelDelta() const;
+
+	// 커서의 현재 스크린 포지션을 캐싱
+	void CacheCursorPosition();
+
+	/**
+	 * 캐싱된 스크린 포지션을 기반으로 위치 고정.
+	 * SetCursorPos를 내부에서 사용하며, 이 함수는 스크린 포지션을 받음.
+	 */
+	void FixMouseCursor();
 	
 private:
 	uint32 WindowWidth;
@@ -57,11 +68,27 @@ private:
 		bool LeftDown = false;
 		bool RightDown = false;
 		bool MiddleDown = false;
-		int32 Wheel = 0; // Delta
+		
+		int32 Wheel = 0; // 누적되는 값
+		
 		int32 X = 0;
 		int32 Y = 0;
+
+		/**
+		 * 윈도우 메시지를 통한 자동 업데이트 대신 원하는 시점에 위치 정보를 업데이트하기 위해 별도로 저장.
+		 * 이 값을 이용해서 시야 회전시 커서를 고정시켜 자유로운 시점 회전이 가능하게 됨.
+		 * 윈도우 메시지는 커서를 고정시킴으로 인해 발생하는 커서의 위치 이동 또한 전달해주므로,
+		 * 커서를 고정하면 시점 또한 고정되는 문제 발생.
+		 * 따라서, 원하는 시점에만 위치를 업데이트할 수 있는 GetCursorPos를 별도로 사용 및
+		 * 해당 값을 통해 스크린 위치에서의 커서 위치를 고정할 수 있음.
+		 */
+		int32 ScreenX = 0; 
+		int32 ScreenY = 0;
 	};
 
 	MouseState PrevMouseState;
 	MouseState CurrentMouseState;
+
+	int32 CachedMouseX = 0;
+	int32 CachedMouseY = 0;
 };

--- a/Engine/Source/Core/Input/PlayerInput.h
+++ b/Engine/Source/Core/Input/PlayerInput.h
@@ -34,7 +34,7 @@ public:
 	// 윈도우 상대적인 마우스 위치 값
 	void GetMousePosition(int32& OutX, int32& OutY) const;
 
-	void GetMousePositionNDC(int32& OutX, int32& OutY) const;
+	void GetMousePositionNDC(float& OutX, float& OutY) const;
 
 	int32 GetMouseWheel() const;
 

--- a/Engine/Source/Core/Rendering/UI.cpp
+++ b/Engine/Source/Core/Rendering/UI.cpp
@@ -83,11 +83,16 @@ void UI::Update()
 
     if (bShowDemoWindow)
 		ImGui::ShowDemoWindow(&bShowDemoWindow);
-    
-    RenderControlPanelWindow();
-    RenderPropertyWindow();
+
+    bool bIsHoveredControlPanel = false;
+    bool bIsHoveredProperty = false;
+    bool bIsHoveredSceneManager = false;
+    RenderControlPanelWindow(bIsHoveredControlPanel);
+    RenderPropertyWindow(bIsHoveredProperty);
     Debug::ShowConsole(bWasWindowSizeUpdated, PreRatio, CurRatio);
-    RenderSceneManager();
+    RenderSceneManagerWindow(bIsHoveredSceneManager);
+
+    bool bIsAnyHovered = bIsHoveredControlPanel || bIsHoveredProperty || bIsHoveredSceneManager;
 
     // UI::RenderSomePanel 들에 대한 업데이트 완료 //
     bWasWindowSizeUpdated = false;
@@ -98,6 +103,9 @@ void UI::Update()
 	// Render ImGui //
     ImGui::Render();
     ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
+
+    bool bUiInput = bIsAnyHovered || ImGui::IsAnyItemHovered() || ImGui::IsAnyItemActive();
+    APlayerController::Get().SetIsUiInput(bUiInput);
 }
 
 
@@ -123,7 +131,7 @@ void UI::OnUpdateWindowSize(UINT InScreenWidth, UINT InScreenHeight)
     UEditorDesigner::Get().OnResize(InScreenWidth, InScreenHeight);
 }
 
-void UI::RenderControlPanelWindow()
+void UI::RenderControlPanelWindow(bool& bOutHovered)
 {
     ImGui::Begin("Jungle Control Panel");
 
@@ -146,7 +154,7 @@ void UI::RenderControlPanelWindow()
 
     ImGui::Text("FPS: %.3f (what is that ms)", ImGui::GetIO().Framerate);
     RenderMemoryUsage();
-
+    
     ImGui::Separator();
 
     RenderPrimitiveSelection();
@@ -176,6 +184,7 @@ void UI::RenderControlPanelWindow()
 	ImGui::SameLine();
     ImGui::Checkbox("Demo Window", &bShowDemoWindow);
 
+    bOutHovered = ImGui::IsWindowHovered();
     ImGui::End();
 }
 
@@ -387,7 +396,7 @@ void UI::RenderRenderMode()
     ImGui::Separator();
 }
 
-void UI::RenderPropertyWindow()
+void UI::RenderPropertyWindow(bool& bOutHovered)
 {
     ImGui::Begin("Properties");
 
@@ -444,6 +453,7 @@ void UI::RenderPropertyWindow()
             }
         }
     }
+    bOutHovered = ImGui::IsWindowHovered();
     ImGui::End();
 }
 
@@ -474,7 +484,7 @@ void UI::RenderDebugRaycast()
     }
 }
 
-void UI::RenderSceneManager()
+void UI::RenderSceneManagerWindow(bool& bOutHovered)
 {
     ImGui::Begin("Scene Manager");
 
@@ -509,7 +519,7 @@ void UI::RenderSceneManager()
         
         ImGui::TreePop();
     }
-
+    bOutHovered = ImGui::IsWindowHovered();
     ImGui::End();
 }
 

--- a/Engine/Source/Core/Rendering/UI.cpp
+++ b/Engine/Source/Core/Rendering/UI.cpp
@@ -23,6 +23,8 @@
 #include "ImGui/imgui_impl_dx11.h"
 #include "ImGui/imgui_impl_win32.h"
 #include "ImGui/imgui_internal.h"
+#include "Input/PlayerController.h"
+#include "Input/PlayerInput.h"
 
 //@TODO: Replace with EditorWindow
 
@@ -345,7 +347,14 @@ void UI::RenderCameraSettings()
         Transform.SetRotation(UIEulerAngle);
         Camera->SetActorTransform(Transform);
     }
-    ImGui::DragFloat("Camera Speed", &Camera->CameraSpeed, 0.1f);
+
+    float CurrentSpeed = APlayerController::Get().GetCurrentSpeed();
+    const float CameraMaxSpeed = APlayerController::Get().GetMaxSpeed();
+    const float CameraMinSpeed = APlayerController::Get().GetMinSpeed();
+    if (ImGui::DragFloat("Camera Speed", &CurrentSpeed, 0.1f, CameraMinSpeed, CameraMaxSpeed))
+    {
+        APlayerController::Get().SetCurrentSpeed(CurrentSpeed);
+    }
 
     FVector Forward = Camera->GetActorTransform().GetForward();
     FVector Up = Camera->GetActorTransform().GetUp();

--- a/Engine/Source/Core/Rendering/UI.h
+++ b/Engine/Source/Core/Rendering/UI.h
@@ -23,15 +23,15 @@ public:
 	void OnUpdateWindowSize(UINT InScreenWidth, UINT InScreenHeight);
 
 public:// UIWindows
-	void RenderControlPanelWindow();
+	void RenderControlPanelWindow(bool& bOutHovered);
 	void RenderMemoryUsage();
 	void RenderPrimitiveSelection();
 	void RenderCameraSettings();
 	void RenderRenderMode();
-	void RenderPropertyWindow();
+	void RenderPropertyWindow(bool& bOutHovered);
 	void RenderGridGap();
 	void RenderDebugRaycast();
-	void RenderSceneManager();
+	void RenderSceneManagerWindow(bool& bOutHovered);
 
 private:
 	void PreferenceStyle();

--- a/Engine/Source/CoreUObject/World.cpp
+++ b/Engine/Source/CoreUObject/World.cpp
@@ -14,7 +14,7 @@
 #include "Engine/GameFrameWork/Cube.h"
 #include "Engine/GameFrameWork/Cylinder.h"
 #include "Engine/GameFrameWork/Sphere.h"
-
+#include "Input/PlayerController.h"
 
 
 REGISTER_CLASS(UWorld);
@@ -75,7 +75,7 @@ void UWorld::Render(float DeltaTime)
     ACamera* cam = FEditorManager::Get().GetCamera();
     Renderer->UpdateViewMatrix(cam->GetActorTransform());
         
-    if (APlayerInput::Get().IsMousePressed(false))
+    if (!APlayerController::Get().IsUiInput() && APlayerInput::Get().IsMousePressed(false))
     {
         RenderPickingTexture(*Renderer);
     }

--- a/Engine/Source/CoreUObject/World.cpp
+++ b/Engine/Source/CoreUObject/World.cpp
@@ -75,7 +75,7 @@ void UWorld::Render(float DeltaTime)
     ACamera* cam = FEditorManager::Get().GetCamera();
     Renderer->UpdateViewMatrix(cam->GetActorTransform());
         
-    if (APlayerInput::Get().IsPressedMouse(false))
+    if (APlayerInput::Get().IsMousePressed(false))
     {
         RenderPickingTexture(*Renderer);
     }

--- a/Engine/Source/CoreUObject/World.cpp
+++ b/Engine/Source/CoreUObject/World.cpp
@@ -75,7 +75,7 @@ void UWorld::Render(float DeltaTime)
     ACamera* cam = FEditorManager::Get().GetCamera();
     Renderer->UpdateViewMatrix(cam->GetActorTransform());
         
-    if (APlayerInput::Get().GetMouseDown(false))
+    if (APlayerInput::Get().IsPressedMouse(false))
     {
         RenderPickingTexture(*Renderer);
     }

--- a/Engine/Source/Engine/Engine.cpp
+++ b/Engine/Source/Engine/Engine.cpp
@@ -156,6 +156,7 @@ void UEngine::Run()
         // ui Update
         ui.Update();
 
+        // UI입력을 우선으로 처리
         APlayerInput::Get().UpdateInput();
         APlayerController::Get().ProcessPlayerInput(DeltaTime);
 

--- a/Engine/Source/Engine/Engine.cpp
+++ b/Engine/Source/Engine/Engine.cpp
@@ -138,17 +138,8 @@ void UEngine::Run()
             }
         }
 
-        APlayerInput::Get().UpdateInput();
-
         // Handle window being minimized or screen locked
         if (Renderer->IsOccluded()) continue;
-
-        // Handle window resize (we don't resize directly in the WM_SIZE handler)
-        if (ResizeWidth != 0 && ResizeHeight != 0)
-        {
-			//UpdateWindowSize(ResizeWidth, ResizeHeight);
-            
-        }
 
         // Renderer Update
         Renderer->PrepareRender();
@@ -161,12 +152,12 @@ void UEngine::Run()
             World->Render(DeltaTime);
             World->LateTick(DeltaTime);
         }
-
-        // TickPlayerInput
-        APlayerController::Get().ProcessPlayerInput(DeltaTime);
         
         // ui Update
-        ui.Update(); // TODO: 입력 받기 전으로 옮겨보기
+        ui.Update();
+
+        APlayerInput::Get().UpdateInput();
+        APlayerController::Get().ProcessPlayerInput(DeltaTime);
 
         Renderer->SwapBuffer();
 
@@ -281,6 +272,8 @@ void UEngine::UpdateWindowSize(const uint32 InScreenWidth, const uint32 InScreen
         ui.OnUpdateWindowSize(InScreenWidth, InScreenHeight);
     }
 	ResizeWidth = ResizeHeight = 0;
+
+    APlayerInput::Get().SetWindowSize(ScreenWidth, ScreenHeight);
 }
 
 UObject* UEngine::GetObjectByUUID(uint32 InUUID) const

--- a/Engine/Source/Engine/Engine.h
+++ b/Engine/Source/Engine/Engine.h
@@ -82,14 +82,15 @@ private:
     HWND WindowHandle = nullptr;
     HINSTANCE WindowInstance = nullptr;
 
-    int InitializedScreenWidth = 0;
-    int InitializedScreenHeight = 0;
+    uint32 InitializedScreenWidth = 0;
+    uint32 InitializedScreenHeight = 0;
 
-    int ScreenWidth = 0;
-    int ScreenHeight = 0;
+    uint32 ScreenWidth = 0;
+    uint32 ScreenHeight = 0;
 
-    int ResizeWidth = 0;
-	int ResizeHeight = 0;
+    // TODO: remove
+    uint32 ResizeWidth = 0;
+	uint32 ResizeHeight = 0;
 
 private:
 	std::unique_ptr<URenderer> Renderer;

--- a/Engine/Source/Engine/GameFrameWork/Camera.h
+++ b/Engine/Source/Engine/GameFrameWork/Camera.h
@@ -31,8 +31,6 @@ private:
 
 public:
     const float MaxYDegree = 89.8f;
-    //카메라 스피드 IMGui용 나중에 Velocity로 관리하면 없어질애라 편하게 public에서 관리
-    float CameraSpeed = 1.0f;
     
     // 투영 타입 - Perspective, Orthographic
     ECameraProjectionMode::Type ProjectionMode;

--- a/Engine/Source/Engine/GameFrameWork/Picker.cpp
+++ b/Engine/Source/Engine/GameFrameWork/Picker.cpp
@@ -43,7 +43,7 @@ void APicker::LateTick(float DeltaTime)
 {
     AActor::LateTick(DeltaTime);
 
-    if (APlayerInput::Get().IsPressedMouse(false))    //좌클릭
+    if (APlayerInput::Get().IsMousePressed(false))    //좌클릭
     {
         if (!PickByColor())
         {
@@ -53,7 +53,7 @@ void APicker::LateTick(float DeltaTime)
 
 
     // 기즈모 핸들링
-    if (APlayerInput::Get().GetMouseDown(false))    //좌클릭
+    if (APlayerInput::Get().IsMouseDown(false))    //좌클릭
     {
 		HandleGizmo();
     }

--- a/Engine/Source/Engine/GameFrameWork/Picker.cpp
+++ b/Engine/Source/Engine/GameFrameWork/Picker.cpp
@@ -43,18 +43,17 @@ void APicker::LateTick(float DeltaTime)
 {
     AActor::LateTick(DeltaTime);
 
-    if (APlayerInput::Get().GetMouseDown(false))    //좌클릭
+    if (APlayerInput::Get().IsPressedMouse(false))    //좌클릭
     {
         if (!PickByColor())
         {
             PickByRay();
         }
-
     }
 
 
     // 기즈모 핸들링
-    if (APlayerInput::Get().IsPressedMouse(false))    //좌클릭
+    if (APlayerInput::Get().GetMouseDown(false))    //좌클릭
     {
 		HandleGizmo();
     }

--- a/Engine/Source/Engine/GameFrameWork/Picker.cpp
+++ b/Engine/Source/Engine/GameFrameWork/Picker.cpp
@@ -9,6 +9,7 @@
 #include "Camera.h"
 #include "Core/Math/Ray.h"
 #include "World.h"
+#include "Input/PlayerController.h"
 #include "Static/EditorManager.h"
 
 REGISTER_CLASS(APicker);
@@ -42,6 +43,11 @@ void APicker::Tick(float DeltaTime)
 void APicker::LateTick(float DeltaTime)
 {
     AActor::LateTick(DeltaTime);
+
+    if (APlayerController::Get().IsUiInput())
+    {
+        return;
+    }
 
     if (APlayerInput::Get().IsMousePressed(false))    //좌클릭
     {

--- a/Engine/Source/Engine/GameFrameWork/Picker.cpp
+++ b/Engine/Source/Engine/GameFrameWork/Picker.cpp
@@ -73,22 +73,16 @@ const char* APicker::GetTypeName()
 
 bool APicker::PickByColor()
 {
-    bool bIsPicked = false;
-    POINT pt;
-    GetCursorPos(&pt);
-    ScreenToClient(UEngine::Get().GetWindowHandle(), &pt);
+    int32 X = 0;
+    int32 Y = 0;
+    APlayerInput::Get().GetMousePosition(X, Y);
 
-    //float ratioX = 1920 / (float)UEngine::Get().GetScreenWidth();
-    //float ratioY = 1080 / (float)UEngine::Get().GetScreenHeight();
-    //pt.x = pt.x * ratioX;
-    //pt.y = pt.y * ratioY;
-
-    FVector4 color = UEngine::Get().GetRenderer()->GetPixel(FVector(pt.x, pt.y, 0));
-
+    FVector4 color = UEngine::Get().GetRenderer()->GetPixel(FVector(X, Y, 0));
     uint32_t UUID = DecodeUUID(color);
 
     UActorComponent* PickedComponent = UEngine::Get().GetObjectByUUID<UActorComponent>(UUID);
 
+    bool bIsPicked = false;
     if (PickedComponent != nullptr)
     {
         bIsPicked = true;
@@ -144,10 +138,11 @@ bool APicker::PickByRay()
 
 void APicker::HandleGizmo()
 {
-    POINT pt;
-    GetCursorPos(&pt);
-    ScreenToClient(UEngine::Get().GetWindowHandle(), &pt);
-    FVector4 color = UEngine::Get().GetRenderer()->GetPixel(FVector(pt.x, pt.y, 0));
+    int32 X = 0;
+    int32 Y = 0;
+    APlayerInput::Get().GetMousePosition(X, Y);
+    
+    FVector4 color = UEngine::Get().GetRenderer()->GetPixel(FVector(X, Y, 0.f));
     uint32_t UUID = DecodeUUID(color);
 
     UActorComponent* PickedComponent = UEngine::Get().GetObjectByUUID<UActorComponent>(UUID);

--- a/Engine/Source/Gizmo/GizmoHandle.cpp
+++ b/Engine/Source/Gizmo/GizmoHandle.cpp
@@ -101,7 +101,7 @@ void AGizmoHandle::Tick(float DeltaTime)
 		}
 	}
 
-    if (APlayerInput::Get().GetKeyDown(EKeyCode::Space))
+    if (APlayerInput::Get().GetKeyDown(DirectX::Keyboard::Keys::Space))
     {
         int type = static_cast<int>(GizmoType);
         type = (type + 1) % static_cast<int>(EGizmoType::Max);

--- a/Engine/Source/Gizmo/GizmoHandle.cpp
+++ b/Engine/Source/Gizmo/GizmoHandle.cpp
@@ -101,7 +101,7 @@ void AGizmoHandle::Tick(float DeltaTime)
 		}
 	}
 
-    if (APlayerInput::Get().GetKeyDown(DirectX::Keyboard::Keys::Space))
+    if (APlayerInput::Get().IsKeyDown(DirectX::Keyboard::Keys::Space))
     {
         int type = static_cast<int>(GizmoType);
         type = (type + 1) % static_cast<int>(EGizmoType::Max);


### PR DESCRIPTION
* APlayerInput 다시 작성
* 카메라 시점 이동 시 커서 숨김 및 커서 위치를 고정하여 제한 없이 회전 가능
* UI에 커서 호버, 포커스, 캡처 중일때에는 월드에 입력 받지 않게 제한
* Camera의 역할을 제한하여 속도 관련 옵션은 PlayerController로 이동