### PR TITLE
Fix/flicker

### DIFF
--- a/Engine/Shaders/ShaderGrid.hlsl
+++ b/Engine/Shaders/ShaderGrid.hlsl
@@ -65,8 +65,8 @@ float4 mainPS(PS_INPUT input) : SV_TARGET
 {
     float Dist = length(input.WorldPosition.xyz - ViewPosition);
 
-    float MaxDist = FarClip * 0.8f;
-    float MinDist = MaxDist * 0.2f;
+    float MaxDist = FarClip * 1.2f;
+    float MinDist = MaxDist * 0.5f;
 
     // Fade out grid
     float Fade = saturate(1.f - (Dist - MinDist) / (MaxDist - MinDist));

--- a/Engine/Shaders/ShaderMain.hlsl
+++ b/Engine/Shaders/ShaderMain.hlsl
@@ -22,14 +22,9 @@ cbuffer ChangeOnResizeAndFov : register(b2)
     float FarClip;
 }
 
-cbuffer UUIDColor : register(b3){
+cbuffer UUIDColor : register(b3)
+{
     float4 UUIDColor;
-}
-
-cbuffer Depth : register(b4){
-    int depth;
-    int nearPlane;
-    int farPlane;
 }
 
 ////////
@@ -47,12 +42,6 @@ struct PS_INPUT
     float4 color : COLOR;          // Color to pass to the pixel shader
 };
 
-struct PS_OUTPUT
-{
-    float4 color : SV_TARGET;
-    float depth : SV_Depth;
-};
-
 ////////
 /// Function
 ////////
@@ -68,29 +57,12 @@ PS_INPUT mainVS(VS_INPUT input)
     return output;
 }
 
-PS_OUTPUT mainPS(PS_INPUT input) : SV_TARGET
+float4 mainPS(PS_INPUT input) : SV_TARGET
 {
-    PS_OUTPUT output;
-
-    // 기본 깊이 값 계산 (0.0~1.0)
-    // float baseDepth = input.depthPosition.z / input.depthPosition.w;
-
-    // 색상 설정 (예: 흰색)
-    output.color = input.color;
-    output.depth = saturate(depth);
-    // output.color = float4(depth, depth, depth, 1.0f);
-    
-    return output;
+    return input.color;
 }
 
-float4 outlinePS(PS_INPUT input) : SV_TARGET
+float4 PickingPS(PS_INPUT input) : SV_TARGET
 {
-    // Output the color directly
-    return float4(1.0f, 0.647f, 0.0f, 0.1f);
-}
-
-PS_OUTPUT PickingPS(PS_INPUT input):SV_TARGET{
-    PS_OUTPUT output;
-    output.color = UUIDColor;
-    return output;
+    return UUIDColor;
 }

--- a/Engine/Shaders/ShaderTexture.hlsl
+++ b/Engine/Shaders/ShaderTexture.hlsl
@@ -1,20 +1,26 @@
+
 Texture2D TextureMap : register(t0);
+
 SamplerState SampleType : register(s0);
+
 cbuffer TextureBuffer : register(b5)
 {
     matrix WorldViewProj;
     float2 UVOffset;
 }
+
 struct VS_INPUT
 {
     float3 Position : POSITION;
     float2 Tex : TEXCOORD0;
 };
+
 struct PS_INPUT
 {
     float4 Position : SV_POSITION;
     float2 Tex : TEXCOORD0;
 };
+
 PS_INPUT mainVS(VS_INPUT Input)
 {
     PS_INPUT Output;
@@ -23,7 +29,8 @@ PS_INPUT mainVS(VS_INPUT Input)
     Output.Tex = Input.Tex + UVOffset;
     return Output;
 }
+
 float4 mainPS(PS_INPUT input) : SV_TARGET
 {
-    return TextureMap.Sample(SampleType, input.Tex);
+    return pow(TextureMap.Sample(SampleType, input.Tex), 2); // to sRGB
 }

--- a/Engine/Source/Core/Input/PlayerController.cpp
+++ b/Engine/Source/Core/Input/PlayerController.cpp
@@ -14,7 +14,13 @@ APlayerController::APlayerController()
     , MaxSpeed(10.f)
     , MinSpeed(1.0f)
     , MouseSensitivity(10.f)
+    , MaxSensitivity(20.f)
+    , MinSensitivity(1.f)
 {}
+
+APlayerController::~APlayerController()
+{
+}
 
 void APlayerController::HandleCameraMovement(float DeltaTime)
 {
@@ -141,9 +147,18 @@ void APlayerController::SaveCameraProperties(ACamera* Camera)
     UEngine::Get().GetEngineConfig()->SaveEngineConfig(EEngineConfigValueType::EEC_EditorCameraRotY, CameraTransform.GetRotation().Y);
     UEngine::Get().GetEngineConfig()->SaveEngineConfig(EEngineConfigValueType::EEC_EditorCameraRotZ, CameraTransform.GetRotation().Z);
     UEngine::Get().GetEngineConfig()->SaveEngineConfig(EEngineConfigValueType::EEC_EditorCameraRotW, CameraTransform.GetRotation().W);
+}
 
-    UEngine::Get().GetEngineConfig()->SaveEngineConfig(EEngineConfigValueType::EEC_EditorCameraSpeed, CameraSpeed);
+void APlayerController::SetCurrentSpeed(float InSpeed)
+{
+    CurrentSpeed = FMath::Clamp(InSpeed, MinSpeed, MaxSpeed);
+    UEngine::Get().GetEngineConfig()->SaveEngineConfig(EEngineConfigValueType::EEC_EditorCameraSpeed, CurrentSpeed);
+}
 
+void APlayerController::SetMouseSensitivity(float InSensitivity)
+{
+    MouseSensitivity = FMath::Clamp(InSensitivity, MinSensitivity, MaxSensitivity);
+    UEngine::Get().GetEngineConfig()->SaveEngineConfig(EEngineConfigValueType::EEC_EditorCameraSensitivity, MouseSensitivity);
 }
 
 void APlayerController::ProcessPlayerInput(float DeltaTime)

--- a/Engine/Source/Core/Input/PlayerController.h
+++ b/Engine/Source/Core/Input/PlayerController.h
@@ -8,6 +8,7 @@ class APlayerController : public TSingleton<APlayerController>
 	
 public :
 	APlayerController();
+	~APlayerController();
 
 	void ProcessPlayerInput(float DeltaTime);
 
@@ -19,10 +20,13 @@ public :
 	float GetMaxSpeed() const { return MaxSpeed; }
 	float GetMinSpeed() const { return MinSpeed; }
 
-	void SetCurrentSpeed(float InSpeed) { CurrentSpeed = InSpeed; }
+	void SetCurrentSpeed(float InSpeed);
 
 	float GetMouseSensitivity() const { return MouseSensitivity; }
-	void SetMouseSensitivity(float InSensitivity) { MouseSensitivity = InSensitivity;}
+	float GetMaxSensitivity() const { return MaxSensitivity; }
+	float GetMinSensitivity() const { return MinSensitivity; }
+	
+	void SetMouseSensitivity(float InSensitivity);
 
 	// TODO: 함수랑 변수 이름 맘에 안듬
 	bool IsUiInput() const { return bUiInput; }
@@ -34,6 +38,8 @@ protected:
 	float MinSpeed;
 
 	float MouseSensitivity;
+	float MaxSensitivity;
+	float MinSensitivity;
 
 	bool bIsHandlingGizmo;
 

--- a/Engine/Source/Core/Rendering/Constants.h
+++ b/Engine/Source/Core/Rendering/Constants.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 struct FMatrix;
 struct FVector;
 #include "Engine/Engine.h"
@@ -13,7 +13,7 @@ struct alignas(16) FCbChangeEveryObject
 };
 
 // 한 프레임에 한번 바뀌는 값
-struct alignas(16) FCbChangeEveryFrame
+struct alignas(16) FCbChangeOnCameraMove
 {
 	FMatrix ViewMatrix;
 	FVector ViewPosition;

--- a/Engine/Source/Core/Rendering/UI.cpp
+++ b/Engine/Source/Core/Rendering/UI.cpp
@@ -400,6 +400,12 @@ void UI::RenderRenderMode()
 			Renderer->SetRenderMode(EViewModeIndex::ERS_Wireframe);
 		}
 	}
+
+    bool bShowPrimitives = UEngine::Get().GetShowPrimitives();
+    if (ImGui::Checkbox("Show Primitives", &bShowPrimitives))
+    {
+        UEngine::Get().SetShowPrimitives(bShowPrimitives);
+    }
     
     ImGui::Separator();
 }

--- a/Engine/Source/Core/Rendering/UI.cpp
+++ b/Engine/Source/Core/Rendering/UI.cpp
@@ -365,6 +365,14 @@ void UI::RenderCameraSettings()
         APlayerController::Get().SetCurrentSpeed(CurrentSpeed);
     }
 
+    float CurrentSensitivity = APlayerController::Get().GetMouseSensitivity();
+    const float CameraMaxSensitivity = APlayerController::Get().GetMaxSensitivity();
+    const float CameraMinSensitivity = APlayerController::Get().GetMinSensitivity();
+    if (ImGui::DragFloat("Camera Sensitivity", &CurrentSensitivity, 0.1f, CameraMinSensitivity, CameraMaxSensitivity))
+    {
+        APlayerController::Get().SetMouseSensitivity(CurrentSensitivity);
+    }
+
     FVector Forward = Camera->GetActorTransform().GetForward();
     FVector Up = Camera->GetActorTransform().GetUp();
     FVector Right = Camera->GetActorTransform().GetRight();

--- a/Engine/Source/Core/Rendering/URenderer.h
+++ b/Engine/Source/Core/Rendering/URenderer.h
@@ -252,6 +252,7 @@ private:
 protected:
 	// 피킹용 버퍼들
 	ID3D11Texture2D* PickingFrameBuffer = nullptr;                 // 화면 출력용 텍스처
+	ID3D11Texture2D* PickingFrameBufferStaging = nullptr;
 	ID3D11RenderTargetView* PickingFrameBufferRTV = nullptr;       // 텍스처를 렌더 타겟으로 사용하는 뷰
 	ID3D11Buffer* ConstantPickingBuffer = nullptr;                 // 뷰 상수 버퍼
 	FLOAT PickingClearColor[4] = { 1.0f, 1.0f, 1.0f, 1.0f }; //
@@ -273,7 +274,7 @@ public:
 	void PrepareMain();
 	void PrepareMainShader();
 
-	FVector4 GetPixel(FVector MPos);
+	FVector4 GetPixel(int32 X, int32 Y);
 
 	void RenderPickingTexture();
 	FMatrix GetProjectionMatrix() const;

--- a/Engine/Source/Core/Rendering/URenderer.h
+++ b/Engine/Source/Core/Rendering/URenderer.h
@@ -7,7 +7,6 @@
 #include "UI.h"
 #include "Core/Math/Vector.h"
 #include "Core/Math/Matrix.h"
-#include "Core/Math/Plane.h"
 #include "Primitive/PrimitiveVertices.h"
 #include "RendererDefine.h"
 #include "Constants.h"
@@ -192,7 +191,7 @@ protected:
 	EViewModeIndex CurrentRasterizerStateType = EViewModeIndex::ERS_Solid; // 현재 사용중인 레스터라이즈 상태 타입
 
 	ID3D11Buffer* CbChangeEveryObject = nullptr;                 // 쉐이더에 데이터를 전달하기 위한 상수 버퍼
-	ID3D11Buffer* CbChangeEveryFrame = nullptr;                  // 쉐이더에 데이터를 전달하기 위한 상수 버퍼
+	ID3D11Buffer* CbChangeOnCameraMove = nullptr;                  // 쉐이더에 데이터를 전달하기 위한 상수 버퍼
 	ID3D11Buffer* CbChangeOnResizeAndFov = nullptr;              // 쉐이더에 데이터를 전달하기 위한 상수 버퍼
 
 	FLOAT ClearColor[4] = { 0.025f, 0.025f, 0.025f, 1.0f }; // 화면을 초기화(clear)할 때 사용할 색상 (RGBA)
@@ -277,6 +276,7 @@ public:
 	FVector4 GetPixel(FVector MPos);
 
 	void RenderPickingTexture();
-	FMatrix GetProjectionMatrix() const { return ProjectionMatrix; }
+	FMatrix GetProjectionMatrix() const;
+	
 #pragma endregion picking
 };

--- a/Engine/Source/Core/Rendering/URenderer.h
+++ b/Engine/Source/Core/Rendering/URenderer.h
@@ -253,11 +253,12 @@ protected:
 	// 피킹용 버퍼들
 	ID3D11Texture2D* PickingFrameBuffer = nullptr;                 // 화면 출력용 텍스처
 	ID3D11Texture2D* PickingFrameBufferStaging = nullptr;
+	ID3D11Texture2D* PickingDepthStencilBuffer = nullptr;
+	ID3D11DepthStencilView* PickingDepthStencilView = nullptr;
 	ID3D11RenderTargetView* PickingFrameBufferRTV = nullptr;       // 텍스처를 렌더 타겟으로 사용하는 뷰
 	ID3D11Buffer* ConstantPickingBuffer = nullptr;                 // 뷰 상수 버퍼
 	FLOAT PickingClearColor[4] = { 1.0f, 1.0f, 1.0f, 1.0f }; //
 	ID3D11PixelShader* PickingPixelShader = nullptr;         // Pixel의 색상을 결정하는 Pixel 셰이더
-	ID3D11Buffer* ConstantsDepthBuffer = nullptr;
 
 	ID3D11DepthStencilState* IgnoreDepthStencilState = nullptr;   // DepthStencil 상태(깊이 테스트, 스텐실 테스트 등 정의)
 
@@ -269,7 +270,6 @@ public:
 	void PreparePicking();
 	void PreparePickingShader() const;
 	void UpdateConstantPicking(FVector4 UUIDColor) const;
-	void UpdateConstantDepth(int Depth) const;
 
 	void PrepareMain();
 	void PrepareMainShader();

--- a/Engine/Source/CoreUObject/Components/PrimitiveComponent.cpp
+++ b/Engine/Source/CoreUObject/Components/PrimitiveComponent.cpp
@@ -21,11 +21,6 @@ void UPrimitiveComponent::UpdateConstantPicking(const URenderer& Renderer, const
     Renderer.UpdateConstantPicking(UUIDColor);
 }
 
-void UPrimitiveComponent::UpdateConstantDepth(const URenderer& Renderer, const int Depth)const
-{
-    Renderer.UpdateConstantDepth(Depth);
-}
-
 void UPrimitiveComponent::Render()
 {
     URenderer* Renderer = UEngine::Get().GetRenderer();

--- a/Engine/Source/CoreUObject/Components/PrimitiveComponent.h
+++ b/Engine/Source/CoreUObject/Components/PrimitiveComponent.h
@@ -18,7 +18,6 @@ public:
 	virtual void BeginPlay() override;
 	virtual void Tick(float DeltaTime) override;
 	void UpdateConstantPicking(const URenderer& Renderer, FVector4 UUIDColor) const;
-	void UpdateConstantDepth(const URenderer& Renderer, int Depth) const;
 	virtual void Render();
 
 	EPrimitiveType GetType() { return Type; }

--- a/Engine/Source/CoreUObject/World.cpp
+++ b/Engine/Source/CoreUObject/World.cpp
@@ -97,8 +97,7 @@ void UWorld::Render(float DeltaTime)
         
     RenderMainTexture(*Renderer);
 	RenderBoundingBoxes(*Renderer);
-
-
+    
     RenderDebugLines(*Renderer, DeltaTime);
 	RenderBillboard(*Renderer);
 
@@ -112,10 +111,6 @@ void UWorld::RenderPickingTexture(URenderer& Renderer)
 
     for (auto& RenderComponent : RenderComponents)
     {
-        if (RenderComponent->GetOwner()->GetDepth() > 0)
-        {
-                continue;
-        }
         uint32 UUID = RenderComponent->GetUUID();
         RenderComponent->UpdateConstantPicking(Renderer, APicker::EncodeUUID(UUID));
         RenderComponent->Render();
@@ -126,7 +121,6 @@ void UWorld::RenderPickingTexture(URenderer& Renderer)
     {
         uint32 UUID = RenderComponent->GetUUID();
         RenderComponent->UpdateConstantPicking(Renderer, APicker::EncodeUUID(UUID));
-        uint32 depth = RenderComponent->GetOwner()->GetDepth();
         RenderComponent->Render();
     }
 }
@@ -139,17 +133,14 @@ void UWorld::RenderMainTexture(URenderer& Renderer)
     {
         if (RenderComponent->GetOwner()->GetDepth() > 0)
         {
-                continue;
+            continue;
         }
-        uint32 depth = RenderComponent->GetOwner()->GetDepth();
-        // RenderComponent->UpdateConstantDepth(Renderer, depth);
         RenderComponent->Render();
     }
 
     Renderer.PrepareZIgnore();
     for (auto& RenderComponent: ZIgnoreRenderComponents)
     {
-        uint32 depth = RenderComponent->GetOwner()->GetDepth();
         RenderComponent->Render();
     }
 }
@@ -159,7 +150,9 @@ void UWorld::RenderBoundingBoxes(URenderer& Renderer)
     for (FBox* Box : BoundingBoxes)
     {
         if (Box && Box->bCanBeRendered && Box->IsValidBox())
+        {
             Renderer.RenderBox(*Box);
+        }
     }
 }
 
@@ -181,7 +174,9 @@ void UWorld::RenderBillboard(URenderer& Renderer)
 	for (UBillboard* Billboard : BillboardComponents)
 	{
         if(Billboard)
+        {
             Billboard->Render();
+        }
 	}
 }
 
@@ -197,7 +192,7 @@ void UWorld::ClearWorld()
     {
         if (!Actor->IsGizmoActor())
         {
-                DestroyActor(Actor);
+            DestroyActor(Actor);
         }
     }
 

--- a/Engine/Source/CoreUObject/World.cpp
+++ b/Engine/Source/CoreUObject/World.cpp
@@ -129,9 +129,11 @@ void UWorld::RenderMainTexture(URenderer& Renderer)
 {
     Renderer.PrepareMain();
     Renderer.PrepareMainShader();
+
+    bool bRenderPrimitives = UEngine::Get().GetShowPrimitives();
     for (auto& RenderComponent : RenderComponents)
     {
-        if (RenderComponent->GetOwner()->GetDepth() > 0)
+        if (!bRenderPrimitives && !RenderComponent->GetOwner()->IsGizmoActor())
         {
             continue;
         }

--- a/Engine/Source/Engine/Engine.cpp
+++ b/Engine/Source/Engine/Engine.cpp
@@ -264,11 +264,14 @@ void UEngine::InitWorld()
 
 		FQuat CameraRot = FQuat(RotX, RotY, RotZ, RotW);
 		FTransform CameraTransform = FTransform(CameraPos, CameraRot, FVector(1,1,1));
-
 		Camera->SetActorTransform(CameraTransform);
+
 		float CameraSpeed = EngineConfig->GetEngineConfigValue<float>(EEngineConfigValueType::EEC_EditorCameraSpeed, 1.f);
         APlayerController::Get().SetCurrentSpeed(CameraSpeed);
         Renderer->UpdateViewMatrix(CameraTransform);
+
+        float CameraSensitivity = EngineConfig->GetEngineConfigValue<float>(EEngineConfigValueType::EEC_EditorCameraSensitivity, 10.f);
+        APlayerController::Get().SetMouseSensitivity(CameraSensitivity);
     }
 
     //// Test

--- a/Engine/Source/Engine/Engine.cpp
+++ b/Engine/Source/Engine/Engine.cpp
@@ -9,15 +9,13 @@
 #include "CoreUObject/World.h"
 #include "Gizmo/Axis.h"
 #include "GameFrameWork/Camera.h"
+#include "Core/Rendering/TextureLoader.h"
 
 #ifdef _DEBUG
 #pragma comment(lib, "DirectXTK/Libs/x64/Debug/DirectXTK.lib")
 #else
 #pragma comment(lib, "DirectXTK/Libs/x64/Release/DirectXTK.lib")
 #endif
-#include "GameFrameWork/Sphere.h"
-#include "Core/Rendering/TextureLoader.h"
-
 
 class AArrow;
 class APicker;
@@ -65,8 +63,8 @@ LRESULT UEngine::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
             {
                 return 0;
             }
-            int32 Width = static_cast<int32>(LOWORD(lParam));
-            int32 Height = static_cast<int32>(HIWORD(lParam));
+            int32 Width = LOWORD(lParam);
+            int32 Height = HIWORD(lParam);
             UEngine::Get().ResizeWidth = Width;
             UEngine::Get().ResizeHeight = Height;
             UEngine::Get().UpdateWindowSize(Width, Height);
@@ -108,7 +106,6 @@ void UEngine::Initialize(HINSTANCE hInstance, const WCHAR* InWindowTitle, const 
 
     InitRenderer();
 
-    
     InitTextureLoader();
 
     InitializedScreenWidth = ScreenWidth;

--- a/Engine/Source/Engine/Engine.h
+++ b/Engine/Source/Engine/Engine.h
@@ -107,6 +107,10 @@ private:
 private:
 	UI ui;
 
+public:
+    bool GetShowPrimitives() const { return bShowPrimitives; }
+    void SetShowPrimitives(bool InShowPrimitives) { bShowPrimitives = InShowPrimitives; }
+
 private:
     class UWorld* World;
     
@@ -132,6 +136,8 @@ private:
      *   따라서 양쪽으로 길이 1씩 추가해서 402로 설정.
      */
     int32 WorldGridCellPerSide = 402;
+
+    bool bShowPrimitives = true;
     
 public:
     // TArray<std::shared_ptr<UObject>> GObjects;

--- a/Engine/Source/Engine/EngineConfig.h
+++ b/Engine/Source/Engine/EngineConfig.h
@@ -36,6 +36,7 @@ enum class EEngineConfigValueType
 	EEC_EditorCameraRotW,
 
 	EEC_EditorCameraSpeed,
+	EEC_EditorCameraSensitivity,
 
 	EEC_Max,
 };
@@ -83,7 +84,8 @@ static const ConfigMapping ConfigMappings[] = {
 	CONFIG_MAPPING(EEC_EditorCameraRotZ, "EditorCameraRotZ", Float, ECS_Camera),
 	CONFIG_MAPPING(EEC_EditorCameraRotW, "EditorCameraRotW", Float, ECS_Camera),
 
-	CONFIG_MAPPING(EEC_EditorCameraSpeed, "EditorCameraSpeed", Float, ECS_Camera)
+	CONFIG_MAPPING(EEC_EditorCameraSpeed, "EditorCameraSpeed", Float, ECS_Camera),
+	CONFIG_MAPPING(EEC_EditorCameraSensitivity, "EditorCameraSensitivity", Float, ECS_Camera)
 	// !TODO : EngineConfig 추가시 추가
 };
 

--- a/Engine/Source/Engine/GameFrameWork/Camera.cpp
+++ b/Engine/Source/Engine/GameFrameWork/Camera.cpp
@@ -15,19 +15,9 @@ ACamera::ACamera()
 
     RootComponent = AddComponent<USceneComponent>();
 
+    FTransform StartTransform = GetActorTransform();
     FVector StartLocation(3.f, -2.f, 2.f);
-    
-   /* FVector Delta = (FVector::ZeroVector - StartLocation).GetSafeNormal();
-    float Pitch = FMath::RadiansToDegrees(asinf(Delta.Z)) * -1;
-    float Yaw = FMath::RadiansToDegrees(atan2(Delta.Y, Delta.X));
-    FVector StartRotation(0.f, Pitch, Yaw);
-
-    FTransform StartTransform = GetActorTransform();
-
-    StartTransform.SetPosition(StartLocation);
-    StartTransform.SetRotation(StartRotation);*/
-    
-    FTransform StartTransform = GetActorTransform();
+    StartTransform.Translate(StartLocation);
 	StartTransform.LookAt(FVector::ZeroVector);
     SetActorTransform(StartTransform);
 }

--- a/Engine/Source/Engine/GameFrameWork/Picker.cpp
+++ b/Engine/Source/Engine/GameFrameWork/Picker.cpp
@@ -83,7 +83,7 @@ bool APicker::PickByColor()
     int32 Y = 0;
     APlayerInput::Get().GetMousePosition(X, Y);
 
-    FVector4 color = UEngine::Get().GetRenderer()->GetPixel(FVector(X, Y, 0));
+    FVector4 color = UEngine::Get().GetRenderer()->GetPixel(X, Y);
     uint32_t UUID = DecodeUUID(color);
 
     UActorComponent* PickedComponent = UEngine::Get().GetObjectByUUID<UActorComponent>(UUID);
@@ -148,7 +148,7 @@ void APicker::HandleGizmo()
     int32 Y = 0;
     APlayerInput::Get().GetMousePosition(X, Y);
     
-    FVector4 color = UEngine::Get().GetRenderer()->GetPixel(FVector(X, Y, 0.f));
+    FVector4 color = UEngine::Get().GetRenderer()->GetPixel(X, Y);
     uint32_t UUID = DecodeUUID(color);
 
     UActorComponent* PickedComponent = UEngine::Get().GetObjectByUUID<UActorComponent>(UUID);

--- a/Engine/Source/Gizmo/GizmoHandle.cpp
+++ b/Engine/Source/Gizmo/GizmoHandle.cpp
@@ -101,7 +101,7 @@ void AGizmoHandle::Tick(float DeltaTime)
 		}
 	}
 
-    if (APlayerInput::Get().IsKeyDown(DirectX::Keyboard::Keys::Space))
+    if (APlayerInput::Get().IsKeyPressed(DirectX::Keyboard::Keys::Space))
     {
         int type = static_cast<int>(GizmoType);
         type = (type + 1) % static_cast<int>(EGizmoType::Max);


### PR DESCRIPTION
* ID 텍스처 picking 시 플리커링 문제 수정
  - ID 텍스처 전용 뎁스 스텐실 버퍼와 뎁스 스텐실 뷰를 새로 생성해줌으로써 해결
* 텍스처 샘플 후 pow2를 통해 sRGB 값과 유사하게 리턴
* engine.ini 파일에 카메라 감도 저장
* UI에 Show primitive 체크박스 추가
* 사용하지 않는 액터의 depth 옵션 및 depth 상수 버퍼 제거
* 그 외 자잘한 코드 정리